### PR TITLE
Remove ollama and developer model services

### DIFF
--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -57,6 +57,7 @@ spec:
                     "env": [
                       { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
                       { "name": "STORAGE_TYPE", "value": "ConfigMap" },
+                      { "name": "PUSH_TO_RHDH", "value": "False"},
                       { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
                       { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
                     ],
@@ -79,6 +80,7 @@ spec:
                     "env": [
                       { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
                       { "name": "MR_ROUTE", "value": "rhoai-model-registries-rhoai-model-registry-rest" },
+                      { "name": "POLLING_INTERVAL", "value": "10s"},
                       { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
                       { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
                     ],

--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -78,7 +78,7 @@ spec:
                     "name": "rhoai-normalizer",
                     "env": [
                       { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
-                      { "name": "MR_ROUTE", "value": "rhoai-model-registries-modelregistry-public-rest" },
+                      { "name": "MR_ROUTE", "value": "rhoai-model-registries-rhoai-model-registry-rest" },
                       { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
                       { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
                     ],

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -334,14 +334,6 @@ backstage:
           locations:
             - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/rolling-demo/all.yaml
               type: url
-            - type: url
-              target: https://github.com/redhat-ai-dev/model-catalog-example/blob/v0.1/developer-model-service/catalog-info.yaml
-              rules:
-                - allow: [Component, Resource, Api]
-            - type: url
-              target: https://github.com/redhat-ai-dev/model-catalog-example/blob/v0.1/ollama-model-service/catalog-info.yaml
-              rules:
-                - allow: [Component, Resource, Api]
           providers:
             modelCatalog:
               development:


### PR DESCRIPTION
Removes ollama and developer model services from the rolling demo

Also adds two new env vars PUSH_TO_RHDH and POLLING_INTERVAL