### PR TITLE
update techdocs link in  ai-homepage

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -168,7 +168,7 @@ global:
                         title: Openshift
                         icon: https://upload.wikimedia.org/wikipedia/commons/d/d8/Red_Hat_logo.svg
                         link: https://www.redhat.com/en/technologies/cloud-computing/openshift
-      - package: oci://quay.io/karthik_jk/ai-experience:1.6!red-hat-developer-hub-backstage-plugin-ai-experience
+      - package: oci://quay.io/karthik_jk/ai-experience:1.6.1!red-hat-developer-hub-backstage-plugin-ai-experience
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -185,7 +185,7 @@ global:
                     menuItem:
                       icon: aiNewsIcon
                       text: AI News
-      - package: oci://quay.io/karthik_jk/ai-experience:1.6!red-hat-developer-hub-backstage-plugin-ai-experience-backend-dynamic
+      - package: oci://quay.io/karthik_jk/ai-experience:1.6.1!red-hat-developer-hub-backstage-plugin-ai-experience-backend-dynamic
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
         disabled: false


### PR DESCRIPTION


ai-experience plugin `1.6.1` will now point to the RHDH techdocs (`/docs/default/system/red-hat-developer-hub`) created by Ben.


https://github.com/user-attachments/assets/79961387-9e3e-4916-8a51-bc8b7098f51f



