### PR TITLE
[DO NOT MERGE] Bump to RHDH 1.6

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -272,7 +272,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.5"
+        tag: "1.6"
         pullSecrets:
           - quay-pull-secret
       command: []


### PR DESCRIPTION
## PR Description

A small change in `values.yaml` -> moving the RHDH tag from `1.5` to `1.6`. However this upgrades the basis of everything.

Do not merge label as it needs to be merged post-summit

## Notes for the reviewer:

Things I've tried with 1.6:
* Create a software template: Success
* Check pruner behavior: Success
* Check AI Experience: Can see the homepage without an issue
* Check AI News: Can fetch the RSS feed successfully
* Check Model Catalog Bridge: RHOAI registered model shows in the resources 
* Check Model Catalog Plugin:  RHOAI registered model shows in the resources 
