### PR TITLE
Fix RHDH version

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -272,7 +272,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.6"
+        tag: "1.6-88"
         pullSecrets:
           - quay-pull-secret
       command: []


### PR DESCRIPTION
Uses a specific tag for the RHDH version (1.6-88) instead of (1.6)