### PR TITLE
Add csp rules for script src for lightspeed

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -383,7 +383,6 @@ backstage:
               - https://news.mit.edu
             script-src:
               - "'self'"
-              - "'unsafe-eval'"
               - https://cdn.jsdelivr.net
           reading:
             allow:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -381,6 +381,10 @@ backstage:
               - https://instructlab.ai
               - https://quay.io
               - https://news.mit.edu
+            script-src:
+              - "'self'"
+              - "'unsafe-eval'"
+              - https://cdn.jsdelivr.net
           reading:
             allow:
               - host: example.com


### PR DESCRIPTION
Lightspeed attachment preview fails to load the monaco editor, which patternfly loads from a CDN.
```
Content-Security-Policy: The page's settings blocked a script (script-src-elem) at https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js from being executed because it violates the following directive: "script-src 'self' 'unsafe-eval'" 12.98d8e07a.chunk.js:2:482303
```
Adds the CDN to allowed script sources to fix the issue.