### PR TITLE
Reenable bridge

### DIFF
--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -84,6 +84,9 @@ spec:
               cat > "${TEMP_DIR}/rhoai-normalizer.json" <<EOF
               {
                 "name": "rhoai-normalizer",
+                "args": [
+                   "-metrics-address=:8888"
+                ],
                 "env": [
                   { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
                   { "name": "MR_ROUTE", "value": "rhoai-model-registries-rhoai-model-registry-rest" },

--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -171,7 +171,7 @@ spec:
                 add_patch_operation "replace" "/spec/template/spec/containers/$RHOAI_NORMALIZER_INDEX" "${TEMP_DIR}/rhoai-normalizer.json" "false"
               else
                 echo "Container 'rhoai-normalizer' does not exist, will add..."
-                add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/rhoai-normalizer.json" "true"
+                add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/rhoai-normalizer.json" "false"
               fi
 
               if echo "$CONTAINERS" | grep -q '"road-core-sidecar"'; then

--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -168,7 +168,7 @@ spec:
               if echo "$CONTAINERS" | grep -q '"rhoai-normalizer"'; then
                 echo "Container 'rhoai-normalizer' already exists, will replace..."
                 RHOAI_NORMALIZER_INDEX=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o json | jq '.spec.template.spec.containers | map(.name == "rhoai-normalizer") | index(true)')
-                add_patch_operation "replace" "/spec/template/spec/containers/$RHOAI_NORMALIZER_INDEX" "${TEMP_DIR}/rhoai-normalizer.json" "true"
+                add_patch_operation "replace" "/spec/template/spec/containers/$RHOAI_NORMALIZER_INDEX" "${TEMP_DIR}/rhoai-normalizer.json" "false"
               else
                 echo "Container 'rhoai-normalizer' does not exist, will add..."
                 add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/rhoai-normalizer.json" "true"

--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -26,6 +26,83 @@ spec:
               TEMP_DIR=$(mktemp -d)
               PATCH_FILE="${TEMP_DIR}/patch.json"
 
+               # Create temp dir and files
+              TEMP_DIR=$(mktemp -d)
+              PATCH_FILE="${TEMP_DIR}/patch.json"
+
+              # Create the container definition files
+              cat > "${TEMP_DIR}/location.json" <<EOF
+              {
+                "name": "location",
+                "env": [
+                  { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
+                  { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
+                  { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
+                ],
+                "envFrom": [
+                  { "secretRef": { "name": "rhdh-rhoai-bridge-token" } },
+                  { "secretRef": { "name": "ai-rh-developer-hub-env" } }
+                ],
+                "image": "quay.io/redhat-ai-dev/model-catalog-location-service:latest",
+                "imagePullPolicy": "Always",
+                "ports": [{ "containerPort": 9090, "name": "location", "protocol": "TCP" }],
+                "startupProbe": {
+                  "httpGet": { "path": "/.backstage/health/v1/liveness", "port": 7007, "scheme": "HTTP" },
+                  "initialDelaySeconds": 30,
+                  "timeoutSeconds": 4,
+                  "periodSeconds": 20,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "volumeMounts": [{ "mountPath": "/opt/app-root/src/dynamic-plugins-root", "name": "dynamic-plugins-root" }],
+                "workingDir": "/opt/app-root/src"
+              }
+              EOF
+
+              cat > "${TEMP_DIR}/storage-rest.json" <<EOF
+              {
+                "name": "storage-rest",
+                "env": [
+                  { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
+                  { "name": "STORAGE_TYPE", "value": "ConfigMap" },
+                  { "name": "PUSH_TO_RHDH", "value": "False"},
+                  { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
+                  { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
+                ],
+                "envFrom": [
+                  { "secretRef": { "name": "rhdh-rhoai-bridge-token" } },
+                  { "secretRef": { "name": "ai-rh-developer-hub-env" } }
+                ],
+                "image": "quay.io/redhat-ai-dev/model-catalog-storage-rest:latest",
+                "imagePullPolicy": "Always",
+                "ports": [{ "containerPort": 9090, "name": "location", "protocol": "TCP" }],
+                "volumeMounts": [{ "mountPath": "/opt/app-root/src/dynamic-plugins-root", "name": "dynamic-plugins-root" }],
+                "workingDir": "/opt/app-root/src"
+              }
+              EOF
+
+              cat > "${TEMP_DIR}/rhoai-normalizer.json" <<EOF
+              {
+                "name": "rhoai-normalizer",
+                "env": [
+                  { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
+                  { "name": "MR_ROUTE", "value": "rhoai-model-registries-rhoai-model-registry-rest" },
+                  { "name": "POLLING_INTERVAL", "value": "10s"},
+                  { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
+                  { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }
+                ],
+                "envFrom": [
+                  { "secretRef": { "name": "rhdh-rhoai-bridge-token" } },
+                  { "secretRef": { "name": "ai-rh-developer-hub-env" } }
+                ],
+                "image": "quay.io/redhat-ai-dev/model-catalog-rhoai-normalizer:latest",
+                "imagePullPolicy": "Always",
+                "ports": [{ "containerPort": 9090, "name": "location", "protocol": "TCP" }],
+                "volumeMounts": [{ "mountPath": "/opt/app-root/src/dynamic-plugins-root", "name": "dynamic-plugins-root" }],
+                "workingDir": "/opt/app-root/src"
+              }
+              EOF
+
               cat > "${TEMP_DIR}/road-core-sidecar.json" <<EOF
               {
                 "name": "road-core-sidecar",
@@ -65,6 +142,34 @@ spec:
                   echo "  }," >> "$PATCH_FILE"
                 fi
               }
+
+              # check action for each one of the containers
+              if echo "$CONTAINERS" | grep -q '"location"'; then
+                echo "Container 'location' already exists, will replace..."
+                LOCATION_INDEX=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o json | jq '.spec.template.spec.containers | map(.name == "location") | index(true)')
+                add_patch_operation "replace" "/spec/template/spec/containers/$LOCATION_INDEX" "${TEMP_DIR}/location.json" "false"
+              else
+                echo "Container 'location' does not exist, will add..."
+                add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/location.json" "false"
+              fi
+
+              if echo "$CONTAINERS" | grep -q '"storage-rest"'; then
+                echo "Container 'storage-rest' already exists, will replace..."
+                STORAGE_REST_INDEX=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o json | jq '.spec.template.spec.containers | map(.name == "storage-rest") | index(true)')
+                add_patch_operation "replace" "/spec/template/spec/containers/$STORAGE_REST_INDEX" "${TEMP_DIR}/storage-rest.json" "false"
+              else
+                echo "Container 'storage-rest' does not exist, will add..."
+                add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/storage-rest.json" "false"
+              fi
+
+              if echo "$CONTAINERS" | grep -q '"rhoai-normalizer"'; then
+                echo "Container 'rhoai-normalizer' already exists, will replace..."
+                RHOAI_NORMALIZER_INDEX=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o json | jq '.spec.template.spec.containers | map(.name == "rhoai-normalizer") | index(true)')
+                add_patch_operation "replace" "/spec/template/spec/containers/$RHOAI_NORMALIZER_INDEX" "${TEMP_DIR}/rhoai-normalizer.json" "true"
+              else
+                echo "Container 'rhoai-normalizer' does not exist, will add..."
+                add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/rhoai-normalizer.json" "true"
+              fi
 
               if echo "$CONTAINERS" | grep -q '"road-core-sidecar"'; then
                 echo "Container 'road-core-sidecar' already exists, will replace..."

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -389,10 +389,10 @@ backstage:
               - host: '*.openshiftapps.com'
               - host: '10.*:9090'
               - host: '127.0.0.1:9090'
-              - host: '127.0.0.1:8080'
+              - host: '127.0.0.1:8888'
               - host: '127.0.0.1:7070'
               - host: 'localhost:9090'
-              - host: 'localhost:8080'
+              - host: 'localhost:8888'
               - host: 'localhost:7070'
         signInPage: oidc
         catalog:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -290,7 +290,7 @@ global:
               red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
                 apiFactories:
                   - importName: AdoptionInsightsAnalyticsApiFactory
-      - disabled: true
+      - disabled: false
         package: oci://quay.io/redhat-ai-dev/ai-integrations-rhdh:latest!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
       - disabled: false
         package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
@@ -389,8 +389,10 @@ backstage:
               - host: '*.openshiftapps.com'
               - host: '10.*:9090'
               - host: '127.0.0.1:9090'
+              - host: '127.0.0.1:8080'
               - host: '127.0.0.1:7070'
               - host: 'localhost:9090'
+              - host: 'localhost:8080'
               - host: 'localhost:7070'
         signInPage: oidc
         catalog:


### PR DESCRIPTION
Note:  because #19 was merged with commit squashing, I could not revert the 2 disables via `git revert ...` and had to do it manually

Also, I attempted to follow https://github.com/gabemontero/ai-rolling-demo-gitops/blob/main/docs/SETUP_GUIDE.md and test against my cluster for the day, but the initial deploy of backstage failed the and post-sync Job that adds the bridge never got created.

Huddled with @johnmcollier briefly about it, but the net probably is we will have to wait @thepetk gets back and can help us verify this before we merge.