### PR TITLE
Update software templates branch

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -407,7 +407,7 @@ backstage:
               rules:
                 - allow: [Component, System]
               type: url
-            - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/rolling-demo/all.yaml
+            - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/ai-rolling-demo/all.yaml
               type: url
           providers:
             modelCatalog:


### PR DESCRIPTION
Updates the software templates branch to the new `ai-rolling-demo` one which is built on top of the current main.

The change of the branch has done in purpose as rebasing the previous one becomes more and more complicated.

I have tested the current branch and created an application for each one of the templates.

Regarding the old branch I'll rename it to `old-`. For the new one we need to apply the same ruleset as we have right now for the `rolling-demo` one (cc @maysunfaisal)

The `ai-rolling-demo` branch contains a number of updates in regards to the argoCD label, argoCD namespace and RHDH Namespace.