### PR TITLE
Add sign in warning for first time users

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -359,6 +359,15 @@ backstage:
                 signIn:
                   resolvers:
                     - resolver: preferredUsernameMatchingUserEntityName
+              development:
+                metadataUrl: "${KEYCLOAK_METADATA_URL}"
+                clientId: "${KEYCLOAK_CLIENT_ID}"
+                clientSecret: "${KEYCLOAK_CLIENT_SECRET}"
+                callbackUrl: "${RHDH_CALLBACK_URL}"
+                prompt: auto
+                signIn:
+                  resolvers:
+                    - resolver: preferredUsernameMatchingUserEntityName
         backend:
           auth:
             externalAccess:


### PR DESCRIPTION
Adds a warning on the top of the sign in screen, to make clear to first time users that they will have to try again if their first attempt with RH SSO fails.