### PR TITLE
RHDHPAI-1080: remove setting of MR_ROUTE (no longer needed by default)

### DIFF
--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -89,7 +89,6 @@ spec:
                 ],
                 "env": [
                   { "name": "NORMALIZER_FORMAT", "value": "JsonArrayFormat" },
-                  { "name": "MR_ROUTE", "value": "rhoai-model-registry-https" },
                   { "name": "POLLING_INTERVAL", "value": "10s"},
                   { "name": "POD_IP", "valueFrom": { "fieldRef": { "fieldPath": "status.podIP" } } },
                   { "name": "POD_NAMESPACE", "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } } }


### PR DESCRIPTION
no longer needed with https://github.com/redhat-ai-dev/model-catalog-bridge/pull/43 