### PR TITLE
Update rcsconfig to now track RHDH 1.7 RAG

### DIFF
--- a/charts/rhdh/templates/rsconfig.yaml
+++ b/charts/rhdh/templates/rsconfig.yaml
@@ -13,8 +13,8 @@ data:
           - name: dummymodel
     ols_config:
       reference_content:
-        product_docs_index_path: "./vector_db/rhdh_product_docs/1.6"
-        product_docs_index_id: rhdh-product-docs-1_6
+        product_docs_index_path: "./vector_db/rhdh_product_docs/1.7"
+        product_docs_index_id: rhdh-product-docs-1_7
         embeddings_model_path: "./embeddings_model"
       conversation_cache:
         type: memory


### PR DESCRIPTION
- updated the rcsconfig.yaml to now track RHDH 1.7 RAG
    - https://quay.io/repository/redhat-ai-dev/road-core-service?tab=info latest tag has been updated to track RHDH 1.7 RAG

similar to https://github.com/redhat-ai-dev/rosa-gitops/pull/32