### PR TITLE
chore(`rhdh-plugin-gitops-updater`) Update `red-hat-developer-hub-backstage-plugin-lightspeed` to version `1.45.3__1.4.0`

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -45,7 +45,7 @@ global:
         disabled: false
 
       # Lightspeed Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.45.3__1.2.3
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.45.3__1.4.0
         disabled: false
         pluginConfig:
           dynamicPlugins:


### PR DESCRIPTION
## Plugin Update

**Plugin**: `red-hat-developer-hub-backstage-plugin-lightspeed`
**Current Version**: `1.45.3__1.2.3`
**New Version**: `1.45.3__1.4.0`

This PR updates the RHDH plugin to the latest version.

🤖 Generated with [RHDH Plugin GitOps Updater](https://github.com/thepetk/rhdh-plugin-gitops-updater)
