### PR TITLE
chore(`rhdh-plugin-gitops-updater`) Update `red-hat-developer-hub-backstage-plugin-lightspeed-backend` to version `1.45.3__1.4.0`

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -72,7 +72,7 @@ global:
                     config:
                       id: lightspeed
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.45.3__1.2.3
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.45.3__1.4.0
         disabled: false
 
       # MCP Actions plugins


### PR DESCRIPTION
## Plugin Update

**Plugin**: `red-hat-developer-hub-backstage-plugin-lightspeed-backend`
**Current Version**: `1.45.3__1.2.3`
**New Version**: `1.45.3__1.4.0`

This PR updates the RHDH plugin to the latest version.

🤖 Generated with [RHDH Plugin GitOps Updater](https://github.com/thepetk/rhdh-plugin-gitops-updater)
