### PR TITLE
Bump Development RHDH to 1.10

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -348,7 +348,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.9-192"
+        tag: "1.10-88"
         pullSecrets:
           - quay-pull-secret
       command: []


### PR DESCRIPTION
## What does this PR do?

Bumps the development RHDH isntance to 1.10-88, so we can start experimenting with the newer version.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Tested already and should work fine once merged
