### PR TITLE
chore(`rhdh-plugin-gitops-updater`) Update `backstage-community-plugin-argocd` to version `1.45.3__2.4.6`

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -15,7 +15,7 @@ global:
 
       ##### Red Hat Plugins without wrappers #####
       # Plugins for ArgoCD integration
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.45.3__2.4.4
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.45.3__2.4.6
         pluginConfig:
           dynamicPlugins:
             frontend:


### PR DESCRIPTION
## Plugin Update

**Plugin**: `backstage-community-plugin-argocd`
**Current Version**: `1.45.3__2.4.4`
**New Version**: `1.45.3__2.4.6`

This PR updates the RHDH plugin to the latest version.

🤖 Generated with [RHDH Plugin GitOps Updater](https://github.com/thepetk/rhdh-plugin-gitops-updater)
