### PR TITLE
chore(`rhdh-plugin-gitops-updater`) Update `roadiehq-backstage-plugin-argo-cd-backend` to version `1.45.3__4.7.1`

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -39,7 +39,7 @@ global:
                       if:
                         allOf:
                           - isArgocdConfigured
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.45.3__4.6.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.45.3__4.7.1
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-argocd:bs_1.45.3__1.8.1
         disabled: false


### PR DESCRIPTION
## Plugin Update

**Plugin**: `roadiehq-backstage-plugin-argo-cd-backend`
**Current Version**: `1.45.3__4.6.0`
**New Version**: `1.45.3__4.7.1`

This PR updates the RHDH plugin to the latest version.

🤖 Generated with [RHDH Plugin GitOps Updater](https://github.com/thepetk/rhdh-plugin-gitops-updater)
