### PR TITLE
Switch `plugin-updater.yaml` to target `development` and use a GH App

### DIFF
--- a/.github/workflows/plugins-updater.yaml
+++ b/.github/workflows/plugins-updater.yaml
@@ -16,11 +16,19 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Update plugins for next__ and bs_ tags
-              uses: redhat-ai-dev/rhdh-plugin-gitops-updater@711e4cef7ea24ee20defc61d93573425f98084fc # v1.0.7
+              uses: redhat-ai-dev/rhdh-plugin-gitops-updater@2f9907ebb01539c6f344893f2be603e770b93b68 # v1.0.8
               with:
                   config-path: "charts/rhdh/values.yaml"
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ steps.app-token.outputs.token }}
+                  base-branch: development
                   tag-prefixes: |
                       next__
                       bs_

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ The repository maintains a `development` branch that serves as the integration b
 2. **Validate** — The `rhdhai-rhdh-dev` ArgoCD application automatically syncs from the `development` branch, deploying the changes to the `rhdhai-development` namespace for testing.
 3. **Promote** — Once validated, changes are merged into `main`. The `rolling-demo` production application picks them up automatically via ArgoCD's self-heal and auto-sync policies.
 
+## Keeping RHDH Plugins Up-to-Date
+
+### The Plugin Updater (`plugins-updater.yaml`) Workflow
+
+The plugin updater workflow runs nightly (and can be triggered manually via `workflow_dispatch`) to keep all RHDH plugins pinned to their latest available versions.
+
+**What it does:**
+
+1. Checks out the repository.
+2. Runs the [`redhat-ai-dev/rhdh-plugin-gitops-updater`](https://github.com/redhat-ai-dev/rhdh-plugin-gitops-updater) action against `charts/rhdh/values.yaml`.
+3. Scans all `oci:` plugin image tags with the prefixes `bs_`, and resolves the latest available version for each.
+4. Opens a **pull request**, targeting the `development` branch, for each plugin that has a new version available.
+
+This automation ensures that our gitops environment uses always the latest stable versions of rhdh plugins.
+
 ## Rolling demo setup
 
 Some instructions on how to setup an instance of the rolling demo on your own can be found in [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The plugin updater workflow runs nightly (and can be triggered manually via `wor
 4. Opens a **pull request**, targeting the `development` branch, for each plugin that has a new version available.
 
 This automation ensures that our gitops environment uses always the latest stable versions of rhdh plugins.
-
+Once we have sufficiently validated the changes to the `development` branch and want to update the `main` branch, we will manually open a PR from `development` to `main`.
 ## Rolling demo setup
 
 Some instructions on how to setup an instance of the rolling demo on your own can be found in [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)


### PR DESCRIPTION
## What does this PR do?

Uses the latest github action version which supports using a different base branch. We now run the scheduled workflow from `main` but we use as base the `development` -> as we would like all plugin updates to get merged first there.

I'll make sure I have added the new secrets to this repo.

### Which issue(s) does this PR fix

RHIDP-13024

### How to test changes / Special notes to the reviewer

Example PR is here: https://github.com/thepetk/ai-rolling-demo-gitops/pull/21
