### PR TITLE
Add lightspeed CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 * @thepetk @johnmcollier @gabemontero
 
 # Lightspeed and Llama Stack owners
-charts/rhdh/templates/lightspeed-postgres.yaml @maysunfaisal @Jdubrick @JslYoon
+charts/rhdh/templates/lightspeed-postgres.yaml @maysunfaisal @Jdubrick @JslYoon @yangcao77
 # TODO: replace this with llama-stack-config for 1.10 release
-charts/rhdh/templates/llama-stack-run-no-guard-config.yaml @maysunfaisal @Jdubrick @JslYoon
+charts/rhdh/templates/llama-stack-run-no-guard-config.yaml @maysunfaisal @Jdubrick @JslYoon @yangcao77

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # Global owner for the repository
 * @thepetk @johnmcollier @gabemontero
+
+# Lightspeed and Llama Stack owners
+charts/rhdh/templates/lightspeed-postgres.yaml @maysunfaisal @Jdubrick @JslYoon
+# TODO: replace this with llama-stack-config for 1.10 release
+charts/rhdh/templates/llama-stack-run-no-guard-config.yaml @maysunfaisal @Jdubrick @JslYoon


### PR DESCRIPTION
## What does this PR do?

I'm specifying CODEOWNERS for lightspeed related resources so they are automatically assigned as reviewers whenever an automatic update is consumed from `lightspeed-configs` repo.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

N/A