### PR TITLE
Update plugin updater to always checkout to `development`

### DIFF
--- a/.github/workflows/plugins-updater.yaml
+++ b/.github/workflows/plugins-updater.yaml
@@ -15,6 +15,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                  ref: development
 
             - name: Generate GitHub App token
               id: app-token


### PR DESCRIPTION
## What does this PR do?

Quick fix for the workflow to update all rhdh-plugins. We're currently checking out on `main` but we need to switch this to `development` as we have moved all the plugin updates to this branch after https://github.com/redhat-ai-dev/ai-rolling-demo-gitops/pull/115 was merged.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Realized the issue cause https://github.com/redhat-ai-dev/ai-rolling-demo-gitops/pull/119 brought some old plugin versions from `main`. So the action was using the source code in `main` as basis instead of `development`