### PR TITLE
Update image tag for backstage to 1.10-103

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -348,7 +348,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.10-88"
+        tag: "1.10-103"
         pullSecrets:
           - quay-pull-secret
       command: []


### PR DESCRIPTION
## What does this PR do?

Simply bumping up to `1.10-103` for development branch just to make sure we consume the latest updates for the new rhdh image.

### Which issue(s) does this PR fix

RHIDP-11397

### How to test changes / Special notes to the reviewer

Change points to dev and is a minor update. If anything goes wrong we can always revert it. Unfortunately due to an issue we have with ocp clusters I cannot test thoroughly (but that's really shouldn't be a problem)