### PR TITLE
Support non RHOAI installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: install tests
+.PHONY: install install-no-rhoai tests
 
 install:
 	bash setup.sh
+
+install-no-rhoai:
+	SKIP_RHOAI_SETUP=true bash setup.sh
 
 tests:
 	bash scripts/run-tests.sh

--- a/charts/rhdh/templates/model-catalog-rbac.yaml
+++ b/charts/rhdh/templates/model-catalog-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rhoai.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -93,3 +94,4 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: default
 type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/rhdh/templates/rolling-demo-rbac.yaml
+++ b/charts/rhdh/templates/rolling-demo-rbac.yaml
@@ -11,3 +11,27 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sidecars-job-deployment-patcher
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sidecars-job-deployment-patcher{{ if .Values.global.isSecondaryInstance }}-{{ .Release.Namespace }}{{ end }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sidecars-job-deployment-patcher
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}

--- a/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
+++ b/charts/rhdh/templates/rolling-demo-sidecars-job.yaml
@@ -10,6 +10,9 @@ spec:
       containers:
         - name: patch-deployment
           image: quay.io/redhat-ai-dev/utils:latest
+          env:
+            - name: RHOAI_ENABLED
+              value: "{{ .Values.rhoai.enabled }}"
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -31,6 +34,7 @@ spec:
               PATCH_FILE="${TEMP_DIR}/patch.json"
 
               # Create the container definition files
+              if [ "$RHOAI_ENABLED" = "true" ]; then
               cat > "${TEMP_DIR}/location.json" <<EOF
               {
                 "name": "location",
@@ -104,6 +108,7 @@ spec:
                 "workingDir": "/opt/app-root/src"
               }
               EOF
+              fi
 
               cat > "${TEMP_DIR}/lightspeed-core-sidecar.json" <<EOF
               {
@@ -172,6 +177,7 @@ spec:
               }
 
               # check action for each one of the containers
+              if [ "$RHOAI_ENABLED" = "true" ]; then
               # Location: Add/Replace
               if echo "$CONTAINERS" | grep -q '"location"'; then
                 echo "Container 'location' already exists, will replace..."
@@ -200,6 +206,7 @@ spec:
               else
                 echo "Container 'rhoai-normalizer' does not exist, will add..."
                 add_patch_operation "add" "/spec/template/spec/containers/-" "${TEMP_DIR}/rhoai-normalizer.json" "false"
+              fi
               fi
 
               # Lightspeed Core: Add/Replace

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -734,3 +734,5 @@ backstage:
       caCertificate: ""
       destinationCACertificate: ""
       insecureEdgeTerminationPolicy: "Redirect"
+rhoai:
+  enabled: false

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -735,4 +735,4 @@ backstage:
       destinationCACertificate: ""
       insecureEdgeTerminationPolicy: "Redirect"
 rhoai:
-  enabled: false
+  enabled: true

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -163,12 +163,16 @@ No changes.
 After configuring your `scripts/private-env` file, run the setup from the repository root:
 
 ```bash
+# Full install (GPU + RHOAI + Model Catalog)
 make install
+
+# Install without GPU and RHOAI (no NFD, no GPU operator, no Model Catalog sidecars)
+make install-no-rhoai
 ```
 
 The `setup.sh` script automates the entire setup process by calling focused subscripts in order:
 
-1. [`install-operators.sh`](../scripts/install-operators.sh) — installs the required operators (OpenShift GitOps, OpenShift Pipelines, Node Feature Discovery, NVIDIA GPU) and creates the NFD instance and NVIDIA ClusterPolicy.
+1. [`install-operators.sh`](../scripts/install-operators.sh) — installs the required operators (OpenShift GitOps, OpenShift Pipelines, Node Feature Discovery, NVIDIA GPU) and creates the NFD instance and NVIDIA ClusterPolicy. Skipped for NFD and GPU when `SKIP_RHOAI_SETUP=true`.
 2. [`setup-rhoai.sh`](../scripts/setup-rhoai.sh) — applies the ODH Kubeflow Model Registry kustomize and waits for the setup job to complete.
 3. [`setup-argocd.sh`](../scripts/setup-argocd.sh) — retrieves ArgoCD admin credentials and generates an API token.
 4. [`setup-namespaces.sh`](../scripts/setup-namespaces.sh) — creates the RHDH and LightSpeed Postgres namespaces.
@@ -181,8 +185,8 @@ The `setup.sh` script automates the entire setup process by calling focused subs
 
 You can skip earlier steps if they have already been completed on your cluster:
 
-- `SKIP_INSTALL_DEPS=true` — skips operator and instance installation.
-- `SKIP_RHOAI_SETUP=true` — skips the ODH Kubeflow Model Registry setup.
+- `SKIP_INSTALL_DEPS=true` — skips all operator and instance installation.
+- `SKIP_RHOAI_SETUP=true` — skips NFD + GPU operator installation, RHOAI setup, and disables Model Catalog sidecars (`location`, `storage-rest`, `rhoai-normalizer`) and RBAC in the deployed chart. This is what `make install-no-rhoai` sets.
 
 For example, to jump straight to the rolling demo preparation:
 

--- a/scripts/apply-argocd-application.sh
+++ b/scripts/apply-argocd-application.sh
@@ -18,16 +18,26 @@ apply_argocd_application() {
     log_fail
     exit 1
   fi
+  local helm_params
+  if [[ "${SKIP_RHOAI_SETUP}" == "true" ]]; then
+    helm_params="[
+       {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
+       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"}
+     ]"
+  else
+    helm_params="[
+       {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
+       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
+       {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"},
+       {\"name\": \"rhoai.enabled\", \"value\": \"true\"}
+     ]"
+  fi
   if ! yq eval \
     ".metadata.name = \"$argocd_app_name\" |
      .spec.source.repoURL = \"$GITOPS_REPO_URL\" |
      .spec.source.targetRevision = \"$GITOPS_TARGET_REVISION\" |
      .spec.destination.namespace = \"$rhdh_namespace\" |
-     .spec.source.helm.parameters = [
-       {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
-       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
-       {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"}
-     ]" \
+     .spec.source.helm.parameters = ${helm_params}" \
     gitops/application.yaml | oc apply -n openshift-gitops -f - >/dev/null 2>&1; then
     log "Failed to apply gitops/application.yaml."
     log_fail

--- a/scripts/install-operators.sh
+++ b/scripts/install-operators.sh
@@ -232,29 +232,33 @@ install_deps() {
     wait_for_csv "$PIPELINES_OPERATOR_NAMESPACE" "$PIPELINES_OPERATOR_PACKAGE"
   fi
 
-  # install Node Feature Discovery Operator if it doesn't exist
-  if check_operator_exists "$NFD_OPERATOR_NAMESPACE" "$NFD_OPERATOR_PACKAGE"; then
-    log "Node Feature Discovery Operator already installed. Skipping."
+  if [[ "${SKIP_RHOAI_SETUP}" == "true" ]]; then
+    log "SKIP_RHOAI_SETUP=true — skipping NFD and GPU operator installation."
   else
-    log "Node Feature Discovery Operator not found. Installing..."
-    resolve_nfd_starting_csv
-    install_namespaced_operator "$NFD_OPERATOR_NAMESPACE" "nfd-operator-group.yaml" "nfd-subscription.yaml" "$NFD_OPERATOR_PACKAGE"
-    wait_for_csv "$NFD_OPERATOR_NAMESPACE" "$NFD_OPERATOR_PACKAGE"
-    # create NFD instance
-    create_nfd_instance
-    wait_for_nfd_instance
-  fi
+    # install Node Feature Discovery Operator if it doesn't exist
+    if check_operator_exists "$NFD_OPERATOR_NAMESPACE" "$NFD_OPERATOR_PACKAGE"; then
+      log "Node Feature Discovery Operator already installed. Skipping."
+    else
+      log "Node Feature Discovery Operator not found. Installing..."
+      resolve_nfd_starting_csv
+      install_namespaced_operator "$NFD_OPERATOR_NAMESPACE" "nfd-operator-group.yaml" "nfd-subscription.yaml" "$NFD_OPERATOR_PACKAGE"
+      wait_for_csv "$NFD_OPERATOR_NAMESPACE" "$NFD_OPERATOR_PACKAGE"
+      # create NFD instance
+      create_nfd_instance
+      wait_for_nfd_instance
+    fi
 
-  # install Nvidia GPU Operator if it doesn't exist
-  if check_operator_exists "$GPU_OPERATOR_NAMESPACE" "$GPU_OPERATOR_PACKAGE"; then
-    log "NVIDIA GPU Operator already installed. Skipping."
-  else
-    log "NVIDIA GPU Operator not found. Installing..."
-    install_namespaced_operator "$GPU_OPERATOR_NAMESPACE" "gpu-operator-group.yaml" "gpu-operator-subscription.yaml" "$GPU_OPERATOR_PACKAGE"
-    wait_for_csv "$GPU_OPERATOR_NAMESPACE" "$GPU_OPERATOR_PACKAGE"
-    # create ClusterPolicy instance
-    create_cluster_policy
-    wait_for_cluster_policy
+    # install Nvidia GPU Operator if it doesn't exist
+    if check_operator_exists "$GPU_OPERATOR_NAMESPACE" "$GPU_OPERATOR_PACKAGE"; then
+      log "NVIDIA GPU Operator already installed. Skipping."
+    else
+      log "NVIDIA GPU Operator not found. Installing..."
+      install_namespaced_operator "$GPU_OPERATOR_NAMESPACE" "gpu-operator-group.yaml" "gpu-operator-subscription.yaml" "$GPU_OPERATOR_PACKAGE"
+      wait_for_csv "$GPU_OPERATOR_NAMESPACE" "$GPU_OPERATOR_PACKAGE"
+      # create ClusterPolicy instance
+      create_cluster_policy
+      wait_for_cluster_policy
+    fi
   fi
 }
 


### PR DESCRIPTION
## What does this PR do?

The last days we've been experiencing an issue, so we were only able to work with smaller clusters. I have added some updates in the installation scripts so we can exclude completely RHOAI from this process.

This can help us if we want to try rolling demo on smaller clusters

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

run make install-no-rhoai on a clusterbot cluster.
