### PR TITLE
[Development] Update image tag for backstage to 1.10-109

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -348,7 +348,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.10-103"
+        tag: "1.10-109"
         pullSecrets:
           - quay-pull-secret
       command: []


### PR DESCRIPTION
## What does this PR do?

Bumps RHDH version to latest 1.10 to see if this unblocks us from plugin size failure.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Dev promotion