### PR TITLE
[Development] TEMP Revert lightspeed plugins version bump

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -45,7 +45,7 @@ global:
         disabled: false
 
       # Lightspeed Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.1.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.45.3__1.4.0
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -72,7 +72,7 @@ global:
                     config:
                       id: lightspeed
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.1.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.45.3__1.4.0
         disabled: false
 
       # MCP Actions plugins


### PR DESCRIPTION
## What does this PR do?

Temporarily reverting the change to latest lightspeed plugin. Will switch back to latest once we have a newer RHDH image.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Will go ahead and merge so we can silence the alert we're receiving
