### PR TITLE
[Development] Fix RHOAI enabled field behavior on `apply-argocd-application.sh`

### DIFF
--- a/scripts/apply-argocd-application.sh
+++ b/scripts/apply-argocd-application.sh
@@ -22,14 +22,14 @@ apply_argocd_application() {
   if [[ "${SKIP_RHOAI_SETUP}" == "true" ]]; then
     helm_params="[
        {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
-       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"}
+       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
        {\"name\": \"rhoai.enabled\", \"value\": \"false\"}
      ]"
   else
     helm_params="[
        {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
        {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
-       {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"},
+       {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"}
      ]"
   fi
   if ! yq eval \

--- a/scripts/apply-argocd-application.sh
+++ b/scripts/apply-argocd-application.sh
@@ -23,13 +23,13 @@ apply_argocd_application() {
     helm_params="[
        {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
        {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"}
+       {\"name\": \"rhoai.enabled\", \"value\": \"false\"}
      ]"
   else
     helm_params="[
        {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
        {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
        {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"},
-       {\"name\": \"rhoai.enabled\", \"value\": \"true\"}
      ]"
   fi
   if ! yq eval \


### PR DESCRIPTION
## What does this PR do?

Very small change to correct the logic when we run `make install-no-rhoai`.

We use by default in our values -> `rhoai.enabled: true` -> that means when we want to install without RHOAI the `apply-argocd-applications.sh` needs to convert this to `rhoai.enabled: false` (when the `SKIP_RHOAI_SETUP` flag is `true`).

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Already tested on a test cluster