### PR TITLE
(chore): Update rhdh-plugin-gitops-updater version to v1.0.9 in workflow

### DIFF
--- a/.github/workflows/plugins-updater.yaml
+++ b/.github/workflows/plugins-updater.yaml
@@ -26,7 +26,7 @@ jobs:
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Update plugins for next__ and bs_ tags
-              uses: redhat-ai-dev/rhdh-plugin-gitops-updater@2f9907ebb01539c6f344893f2be603e770b93b68 # v1.0.8
+              uses: redhat-ai-dev/rhdh-plugin-gitops-updater@34a96e5374365ae3e007d73f6fc26993bccabd2f # v1.0.9
               with:
                   config-path: "charts/rhdh/values.yaml"
                   github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What does this PR do?

I'm updating `main` by bumping up the `rhdh-plugins-gitops-updater` action. The `v1.0.9` has support for the new structure for our config post lightspeed-GA (see: https://github.com/redhat-ai-dev/rhdh-plugin-gitops-updater). More specifically the new version also takes into account extra locations for plugins (`global.lightspeed.plugins`) and updates them if a new tag of an oci package is available.

This way we will keep updating automatically the plugins we are currently overriding on our `development` branch: https://github.com/redhat-ai-dev/ai-rolling-demo-gitops/blob/development/charts/rhdh/values.yaml#L310-L341

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

I've already tested the new version of the action as part of my PR for `rhdh-plugin-gitops-updater`.
