### PR TITLE
[Development] Update Software Templates for RHDH 1.10

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -479,9 +479,9 @@ backstage:
               rules:
                 - allow: [Component, System]
               type: url
-            - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/ai-rolling-demo-1_9/all.yaml
+            - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/ai-rolling-demo-1_10/all.yaml
               type: url
-            - target: https://github.com/redhat-ai-dev/llama-stack-agentic-sample/blob/ai-rolling-demo-1_9/all.yaml
+            - target: https://github.com/redhat-ai-dev/llama-stack-agentic-sample/blob/ai-rolling-demo-1_10/all.yaml
               type: url
           providers:
             modelCatalog:


### PR DESCRIPTION
## What does this PR do?

Simply switches the target for software templates to the newly created branches for `ai-rolling-demo-1_10` replacing the previous one `ai-rolling-demo-1_9`

### Which issue(s) does this PR fix

RHIDP-11401

### How to test changes / Special notes to the reviewer

- I have already created a new branch in `llama-stack-agentic-sample` with all the necessary Rolling Demo default values included.
- I have opened https://github.com/redhat-ai-dev/ai-lab-template/pull/110/changes to update the `ai-lab-template` -> `ai-rolling-demo-1_10` branch. 
- Once the above PR is merged we can go ahead and merge this one too so we can test on dev that everything is working fine. It should be the case as we didn't have so many changes during the dev cycle of 1.10.