### PR TITLE
[Development] Fix catalog entries and disable gitlab plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The rolling demo combines the following components so far:
 - The github organization set to serve the demo is `ai-rolling-demo`, that said you need to keep it as the `Repository Owner`.
 - Same applies for the `Image Organization` value. The `quay.io` repository corresponding to the demo is `rhdhpai-rolling-demo`.
 
+### Gitlab Plugins Not Suported
+
+- The GitLab catalog discovery plugins (`catalog-backend-module-gitlab-dynamic` and `catalog-backend-module-gitlab-org-dynamic`) are currently disabled. The demo uses GitHub as its only SCM integration and these plugins require a `catalog.providers.gitlab.default.host` configuration that is not available.
+
 ### Model Catalog Bridge
 
 - A pre-requisite for the model catalog bridge to work is a running Red Hat OpenShift AI instance, so the bridge can fetch all registered models and add them to RHDH as catalog entities.

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -290,9 +290,9 @@ global:
       - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
-        disabled: false
+        disabled: true
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
-        disabled: false
+        disabled: true
         
       # Github Plugins
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
@@ -484,8 +484,12 @@ backstage:
               type: url
             - target: https://github.com/redhat-ai-dev/ai-lab-template/blob/ai-rolling-demo-1_10/all.yaml
               type: url
+              rules:
+                - allow: [Component, Location, Template]
             - target: https://github.com/redhat-ai-dev/llama-stack-agentic-sample/blob/ai-rolling-demo-1_10/all.yaml
               type: url
+              rules:
+                - allow: [Component, Location, Template]
           providers:
             modelCatalog:
               development:


### PR DESCRIPTION
## What does this PR do?

I'm setting up specific rules on the catalog entries for all software templates as well as disabling the gitlab catalog plugins as we're now getting an error that the gitlab host is not set (in `backstage-backend`)

I'm adding a new limitation in README to highlight that gitlab is not supported.

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

I'm currently testing the development in general, in order to make sure that everything is in order before we merge to main.

So I'd say let's merge this one in dev and test it there.

Right now we're not able to fetch the templates from `ai-lab-template` and `llama-stack-agentic-sample`. I suspect those two as potential fixes.
