### PR TITLE
enable oauth2 authorization for backsage-cli

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -15,6 +15,16 @@ global:
                   importName: RollingDemoCustomizedSignInPage
 
       ##### Red Hat Plugins without wrappers #####
+      # Plugin for backstage auth
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.49.4__0.1.6
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              backstage.plugin-auth:
+                dynamicRoutes:
+                  - path: /oauth2/*
+                    importName: Router
       # Plugins for ArgoCD integration
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.49.4__2.8.0
         pluginConfig:
@@ -403,6 +413,11 @@ backstage:
               licensedUsers: 50
         auth:
           environment: production
+          # Enable experimental features for OIDC auth
+          experimentalClientIdMetadataDocuments:
+            enabled: true
+          experimentalRefreshToken:
+            enabled: true
           session:
             secret: "${BACKEND_SECRET}"
           providers:


### PR DESCRIPTION
## What does this PR do?
enable oauth2 authorization for `backsage-cli`

### Which issue(s) does this PR fix

related to https://redhat.atlassian.net/browse/RHIDP-14122

the oauth2 authorization is a requirement for using `backsage-cli`


### How to test changes / Special notes to the reviewer

add the changes accordingly, and run:
```
alias backstage-cli='NPM_CONFIG_LEGACY_PEER_DEPS=true npx -y @backstage/cli

backstage-cli auth login --backend-url <rhdh-backend-url>
```
should see the blow authorization page

<img width="897" height="454" alt="Screenshot 2026-06-16 at 4 07 49 PM" src="https://github.com/user-attachments/assets/4914d1eb-2669-4c97-9d7a-e221717b8e72" />
