### PR TITLE
Add warning message for CI check failures

### DIFF
--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -45,6 +45,12 @@ export ARGOCD_HOSTNAME="${ARGOCD_HOSTNAME:-dummy-argocd-hostname}"
 export ARGOCD_API_TOKEN="${ARGOCD_API_TOKEN:-dummy-argocd-token}"
 
 # setup lightspeed required secret values
+if [ -z "${VLLM_URL:-}" ] || [ -z "${VLLM_API_KEY:-}" ] || [ -z "${VALIDATION_PROVIDER:-}" ] || \
+   [ -z "${VALIDATION_MODEL_NAME:-}" ] || [ -z "${LIGHTSPEED_POSTGRES_USER:-}" ] || \
+   [ -z "${LIGHTSPEED_POSTGRES_PASSWORD:-}" ] || [ -z "${LIGHTSPEED_POSTGRES_DB:-}" ] || \
+   [ -z "${NOTEBOOKS_QUERY_PROVIDER_ID:-}" ] || [ -z "${NOTEBOOKS_QUERY_MODEL:-}" ]; then
+  echo "WARNING: Required secrets are not set. Follow the instructions in docs/TESTING.md and set up the secrets on your fork." >&2
+fi
 export ENABLE_VLLM="true"
 export VLLM_URL="${VLLM_URL:?VLLM_URL must be set}"
 export VLLM_API_KEY="${VLLM_API_KEY:?VLLM_API_KEY must be set}"

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -49,7 +49,7 @@ if [ -z "${VLLM_URL:-}" ] || [ -z "${VLLM_API_KEY:-}" ] || [ -z "${VALIDATION_PR
    [ -z "${VALIDATION_MODEL_NAME:-}" ] || [ -z "${LIGHTSPEED_POSTGRES_USER:-}" ] || \
    [ -z "${LIGHTSPEED_POSTGRES_PASSWORD:-}" ] || [ -z "${LIGHTSPEED_POSTGRES_DB:-}" ] || \
    [ -z "${NOTEBOOKS_QUERY_PROVIDER_ID:-}" ] || [ -z "${NOTEBOOKS_QUERY_MODEL:-}" ]; then
-  echo "WARNING: Required secrets are not set. Follow the instructions in docs/TESTING.md and set up the secrets on your fork." >&2
+  echo "WARNING: Required secrets are not set. If you are working from a fork, push your branch to the upstream repo and re-open the PR from there. For local runs, see docs/TESTING.md." >&2
 fi
 export ENABLE_VLLM="true"
 export VLLM_URL="${VLLM_URL:?VLLM_URL must be set}"


### PR DESCRIPTION
## What does this PR do?

I'm adding an error message in the ci test script, just to make it more clear that PRs coming from forks will need to have set secrets on the fork itself (by following the Testing.md file). There might be another way to handle this, however I do feel more comfortable keeping it like this (mostly from security perspective).

### Which issue(s) does this PR fix

N/A

### How to test changes / Special notes to the reviewer

Just an error message, if the CI passes we're good.
