### PR TITLE
[development] Update from Lightspeed to Intelligent Assistant

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -329,34 +329,39 @@ global:
   lightspeed:
     enabled: true
     plugins:
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant:pr_2805__3.0.3
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant:bs_1.52.0__3.0.3
         disabled: false
         pluginConfig:
           dynamicPlugins:
             frontend:
               red-hat-developer-hub.backstage-plugin-intelligent-assistant:
                 translationResources:
-                  - importName: intelligentAssistantTranslations
+                  - importName: lightspeedTranslations
                     module: Alpha
                     ref: intelligentAssistantTranslationRef
                 dynamicRoutes:
                   - path: /intelligent-assistant
                     importName: LightspeedPage
+                    module: Legacy
                 mountPoints:
                   - mountPoint: application/listener
                     importName: LightspeedFAB
+                    module: Legacy
                   - mountPoint: application/provider
                     importName: LightspeedDrawerProvider
+                    module: Legacy
                   - mountPoint: application/internal/drawer-state
                     importName: LightspeedDrawerStateExposer
+                    module: Legacy
                     config:
                       id: intelligent-assistant
                   - mountPoint: application/internal/drawer-content
                     importName: LightspeedChatContainer
+                    module: Legacy
                     config:
                       id: intelligent-assistant
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend:pr_2805__3.0.3
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend:bs_1.52.0__3.0.3
         disabled: false
     secret:
       create: false

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -329,18 +329,18 @@ global:
   lightspeed:
     enabled: true
     plugins:
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.9.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant:pr_2805__3.0.3
         disabled: false
         pluginConfig:
           dynamicPlugins:
             frontend:
-              red-hat-developer-hub.backstage-plugin-lightspeed:
+              red-hat-developer-hub.backstage-plugin-intelligent-assistant:
                 translationResources:
-                  - importName: lightspeedTranslations
+                  - importName: intelligentAssistantTranslations
                     module: Alpha
-                    ref: lightspeedTranslationRef
+                    ref: intelligentAssistantTranslationRef
                 dynamicRoutes:
-                  - path: /lightspeed
+                  - path: /intelligent-assistant
                     importName: LightspeedPage
                 mountPoints:
                   - mountPoint: application/listener
@@ -350,13 +350,13 @@ global:
                   - mountPoint: application/internal/drawer-state
                     importName: LightspeedDrawerStateExposer
                     config:
-                      id: lightspeed
+                      id: intelligent-assistant
                   - mountPoint: application/internal/drawer-content
                     importName: LightspeedChatContainer
                     config:
-                      id: lightspeed
+                      id: intelligent-assistant
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.9.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend:pr_2805__3.0.3
         disabled: false
     secret:
       create: false
@@ -558,7 +558,7 @@ backstage:
                 signIn:
                   resolvers:
                     - resolver: emailMatchingUserEntityProfileEmail
-        lightspeed:
+        intelligent-assistant:
           notebooks:
             enabled: true
             queryDefaults:


### PR DESCRIPTION
## What does this PR do?

Migrates the RHDH dynamic plugin configuration from the legacy `lightspeed` plugin to the new `intelligent-assistant` plugin, following the rename in [rhdh-plugin-export-overlays#2805](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2805) and [rhdh-plugin-export-overlays#2806](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2806).

Changes:
- **OCI images**: Swapped to `intelligent-assistant` and `intelligent-assistant-backend` with release tag `bs_1.52.0__3.0.3`
- **Plugin ID**: `red-hat-developer-hub.backstage-plugin-lightspeed` → `red-hat-developer-hub.backstage-plugin-intelligent-assistant`
- **Route**: `/lightspeed` → `/intelligent-assistant`
- **Config namespace**: `lightspeed:` → `intelligent-assistant:`
- **Drawer IDs**: `id: lightspeed` → `id: intelligent-assistant`
- **Translation ref**: `lightspeedTranslationRef` → `intelligentAssistantTranslationRef`
- **module: Legacy**: Added to all `dynamicRoutes` and `mountPoints` entries, matching the [official plugin metadata](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/workspaces/intelligent-assistant/metadata/rhdh-bsp-intelligent-assistant.yaml)

Note: Component `importName` values (`LightspeedPage`, `LightspeedFAB`, `LightspeedDrawerProvider`, etc.) and translation `importName` (`lightspeedTranslations`) remain unchanged — these are the actual JS export names in the plugin source code, which were intentionally not renamed.

### Which issue(s) does this PR fix

https://redhat.atlassian.net/browse/RHIDP-15897

### How to test changes / Special notes to the reviewer

1. Deploy on a cluster with `make install-no-rhoai`
2. Verify the intelligent-assistant chat drawer loads and responds to queries
3. Verify notebook sessions work (file upload + question answering)

Tested on OpenShift cluster — both chat and notebook features confirmed working.