### PR TITLE
feat: RHIDP-15537 - initial migration of dev instance RHDH to v2.x, with NFS enabled

### DIFF
--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -73,6 +73,18 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-kserve-kubeflow-connector-backend:bs_1.52.0__0.1.1
         disabled: false
 
+      # AI Resource Kind Plugins
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-model-server:bs_1.52.0__0.2.0
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-agent:bs_1.52.0__0.2.1
+        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:pr_3227__0.4.0
+        disabled: false
+
+      # Boost Plugins
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-boost:bs_1.52.0__0.4.0
+        disabled: false
+
       # Tekton Pipelines Plugins
       # Tekton CI Plugins
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tekton:bs_1.52.0__3.41.0
@@ -369,7 +381,7 @@ backstage:
         signInPage: oidc
         catalog:
           rules:
-            - allow: [User, Group, System, Domain, Component, Resource, Location, Template, API, AiResource]
+            - allow: [User, Group, System, Domain, Component, Resource, Location, Template, API, AiResource, AiModelServerAPI]
           locations:
             - target: https://github.com/benwilcock/rhdh-techdocs/blob/main/rhdh-catalog-info.yaml
               rules:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -96,11 +96,8 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-home:bs_1.52.0__0.9.7
         disabled: false
       # RHDH Homepage (customized home page with widgets + root redirect)
-      # Known limitation: homepage frontend expects a visits API (page tracking analytics)
-      # that the homepage-backend plugin doesn't provide. This causes 2 "Something Went Wrong"
-      # error boxes at the bottom of the home page. We accept this cosmetic issue to keep
-      # the RHDH-branded Quick Access widgets and learning paths. The visits API would need
-      # either database schema setup or a different backend plugin version that we don't have.
+      # The "recently-visited" and "top-visited" widgets are disabled via app.extensions
+      # because they require a visits API that the homepage-backend doesn't fully implement.
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__1.17.0
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.52.0__0.4.0
@@ -280,6 +277,10 @@ backstage:
                   redirects:
                     - from: /
                       to: /home
+            # Disable homepage widgets that require the visits API (page tracking analytics)
+            # to avoid "Something Went Wrong" error boxes on the home page
+            - home-page-widget:home/recently-visited: false
+            - home-page-widget:home/top-visited: false
           analytics:
             adoptionInsights:
               maxBufferSize: 20

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -4,52 +4,24 @@ global:
     includes:
       - "dynamic-plugins.default.yaml"
     plugins:
-      ##### Custom sign in page plugin #####
-      - package: oci://quay.io/redhat-ai-dev/rolling-demo-customized-sign-in-page:v0.1.1
+      ##### NFS Frontend Plugins #####
+      # App Auth (NFS sign-in page, replaces custom sign-in page)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-app-auth:bs_1.52.0__0.1.0
         disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-rolling-demo-customized-sign-in-page:
-                signInPage:
-                  importName: RollingDemoCustomizedSignInPage
+      # App Integrations (NFS provider integrations)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-app-integrations:bs_1.52.0__0.1.0
+        disabled: false
+      # App Defaults (NFS default extensions)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-app-defaults:bs_1.52.0__0.0.2
+        disabled: false
+      # Theme
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-theme:bs_1.52.0__1.0.2
+        disabled: false
 
-      ##### Red Hat Plugins without wrappers #####
-      # Plugin for backstage auth
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.52.0__0.1.9
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage.plugin-auth:
-                dynamicRoutes:
-                  - path: /oauth2/*
-                    importName: Router
-      # Plugins for ArgoCD integration
+      ##### Red Hat Plugins #####
+      # ArgoCD (frontend disabled — no NFS version yet; backends kept)
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.49.4__2.8.0
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage-community.plugin-redhat-argocd:
-                mountPoints:
-                  - mountPoint: entity.page.overview/cards
-                    importName: ArgocdDeploymentSummary
-                    config:
-                      layout:
-                        gridColumnEnd:
-                          lg: "span 8"
-                          xs: "span 12"
-                      if:
-                        allOf:
-                          - isArgocdConfigured
-                  - mountPoint: entity.page.cd/cards
-                    importName: ArgocdDeploymentLifecycle
-                    config:
-                      layout:
-                        gridColumn: '1 / -1'
-                      if:
-                        allOf:
-                          - isArgocdConfigured
+        disabled: true
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.49.4__4.8.0
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-argocd:bs_1.49.4__1.8.1
@@ -85,69 +57,32 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-boost:bs_1.52.0__0.4.0
         disabled: false
 
-      # Tekton Pipelines Plugins
-      # Tekton CI Plugins
+      # Tekton CI (NFS — no pluginConfig needed)
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tekton:bs_1.52.0__3.41.0
         disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage-community.plugin-tekton:
-                mountPoints:
-                  - config:
-                      if:
-                        allOf:
-                          - isTektonCIAvailable
-                      layout:
-                        gridColumn: 1 / -1
-                        gridRowStart: 1
-                    importName: TektonCI
-                    mountPoint: entity.page.ci/cards
 
-      ##### Default Backstage Dynamic Plugins #####
-      # Plugin for global header customization
-      # We follow the default plugins setup with a slight diff
-      # on the application-launcher dropdown items
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
+      ##### Default Backstage Dynamic Plugins (OCI images for NFS) #####
+      # Global Header
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header:bs_1.52.0__2.0.0
         disabled: false
-        pluginConfig:
-          app:
-            sidebar:
-              search: false
-              settings: false
-              logo: false
-          dynamicPlugins:
-            frontend:
-              default.main-menu-items:
-                menuItems:
-                  default.create:
-                    title: ''
-                  default.admin:
-                    title: Administration
-                    textKey: menuItem.administration
-                    icon: admin
-                  default.help:
-                    title: RHDH Guide
-                    icon: techdocs
-                    priority: 5
-                    to: /catalog/default/system/rhdh-getting-started/docs
-                    enabled: true
-      # Plugins for Kubernetes integration
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+
+      # Kubernetes
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes-backend:bs_1.52.0__0.21.5
         disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes:bs_1.52.0__0.12.20
         disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+      # Topology
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-topology:bs_1.52.0__2.16.0
         disabled: false
 
       # Catalog plugins
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:pr_2510__3.21.0
         disabled: false
 
-      # TechDocs plugins
-      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
-        disabled: false        
-      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
+      # TechDocs
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs-backend:bs_1.52.0__2.2.1
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs:bs_1.52.0__1.17.7
         disabled: false
 
       # Gitlab Plugins
@@ -180,36 +115,6 @@ global:
     plugins:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant:bs_1.52.0__3.2.0
         disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-intelligent-assistant:
-                translationResources:
-                  - importName: lightspeedTranslations
-                    module: Alpha
-                    ref: intelligentAssistantTranslationRef
-                dynamicRoutes:
-                  - path: /intelligent-assistant
-                    importName: LightspeedPage
-                    module: Legacy
-                mountPoints:
-                  - mountPoint: application/listener
-                    importName: LightspeedFAB
-                    module: Legacy
-                  - mountPoint: application/provider
-                    importName: LightspeedDrawerProvider
-                    module: Legacy
-                  - mountPoint: application/internal/drawer-state
-                    importName: LightspeedDrawerStateExposer
-                    module: Legacy
-                    config:
-                      id: intelligent-assistant
-                  - mountPoint: application/internal/drawer-content
-                    importName: LightspeedChatContainer
-                    module: Legacy
-                    config:
-                      id: intelligent-assistant
-                      priority: 100
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend:bs_1.52.0__3.2.0
         disabled: false
     secret:
@@ -287,8 +192,6 @@ backstage:
           - quay-pull-secret
       command: []
       extraAppConfig:
-        - filename: global-header-app-config.yaml
-          configMapRef: global-header-app-config
         - filename: kserve-connector-app-config.yaml
           configMapRef: kserve-connector-app-config
       appConfig:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -81,7 +81,7 @@ global:
 
       # Catalog plugins
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:pr_2510__3.21.0
-        disabled: false
+        disabled: true
 
       # TechDocs
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs-backend:bs_1.52.0__2.2.1
@@ -100,7 +100,7 @@ global:
       - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
         disabled: true
       - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
-        disabled: true
+        disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
         disabled: true
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -96,6 +96,11 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-home:bs_1.52.0__0.9.7
         disabled: false
       # RHDH Homepage (customized home page with widgets + root redirect)
+      # Known limitation: homepage frontend expects a visits API (page tracking analytics)
+      # that the homepage-backend plugin doesn't provide. This causes 2 "Something Went Wrong"
+      # error boxes at the bottom of the home page. We accept this cosmetic issue to keep
+      # the RHDH-branded Quick Access widgets and learning paths. The visits API would need
+      # either database schema setup or a different backend plugin version that we don't have.
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__1.17.0
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.52.0__0.4.0

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -462,6 +462,7 @@ backstage:
             "/developer-hub":
               target: https://raw.githubusercontent.com
               pathRewrite:
+                "^/api/proxy/developer-hub$": "/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/homepage/plugins/homepage/dev/quickaccess-default.json"
                 "^/api/proxy/developer-hub/learning-paths": "/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/ai-integrations/plugins/ai-experience/src/learning-paths/data.json"
               changeOrigin: true
               secure: false

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -538,6 +538,11 @@ backstage:
         # Only for demo purposes: Remove in production
         - name: NODE_TLS_REJECT_UNAUTHORIZED
           value: "0"
+        # Enable NFS app-next frontend shell (required for pure-NFS plugins like boost)
+        - name: APP_CONFIG_app_packageName
+          value: "app-next"
+        - name: ENABLE_STANDARD_MODULE_FEDERATION
+          value: "true"
       extraEnvVarsSecrets:
         - github-secrets
         - kubernetes-secrets

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -145,6 +145,16 @@ global:
         disabled: true
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
         disabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
+        disabled: true
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-adoption-insights
+        disabled: true
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic
+        disabled: true
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
+        disabled: true
 
       # Gitlab Plugins
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -66,6 +66,22 @@ global:
         disabled: false
 
       ##### Default Backstage Dynamic Plugins (OCI images for NFS) #####
+      # Catalog frontend (NFS page + sidebar nav — PR build, no released version yet)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog:pr_2563__2.0.1
+        disabled: false
+      # Catalog Import
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-import:bs_1.52.0__0.13.14
+        disabled: false
+      # Scaffolder frontend (NFS /create page — PR build)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder:pr_2563__1.36.1
+        disabled: false
+      # Search frontend (NFS /search page — PR build)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-search:pr_2563__1.7.0
+        disabled: false
+      # Home page (NFS / route)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-home:bs_1.52.0__0.9.7
+        disabled: false
+
       # Global Header
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header:bs_1.52.0__2.0.0
         disabled: false
@@ -104,6 +120,11 @@ global:
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
         disabled: true
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+        disabled: true
+      # Disable Scalprum-only frontend plugins that lack NFS support (no mf-manifest.json)
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
+        disabled: true
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
         disabled: true
 
       # Gitlab Plugins

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -42,23 +42,25 @@ global:
         disabled: false
 
       # Model Catalog Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog:bs_1.52.0__1.0.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog:bs_1.52.0__1.0.1
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend:bs_1.52.0__0.6.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend:bs_1.52.0__0.6.1
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-kserve-kubeflow-connector-backend:bs_1.52.0__0.1.1
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-kserve-kubeflow-connector-backend:bs_1.52.0__0.1.2
         disabled: false
 
       # AI Resource Kind Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-model-server:bs_1.52.0__0.2.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-model-server:bs_1.52.0__0.3.0
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-agent:bs_1.52.0__0.2.1
-        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-agent:bs_1.52.0__0.4.0
+        disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:pr_3227__0.4.0
         disabled: false
 
       # Boost Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-boost:bs_1.52.0__0.4.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-boost:bs_1.52.0__0.5.1
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-ogx-entity-provider:bs_1.52.0__0.3.0
         disabled: false
 
       # Tekton CI (NFS — no pluginConfig needed)
@@ -738,54 +740,6 @@ backstage:
               subPath: .npmrc
             - mountPath: /extensions
               name: extensions-catalog
-        # Patch ai-model-server to also register default + AiResource entity models.
-        # Without this, the ModelProcessor only knows AiModelServerAPI and rejects
-        # all standard entity kinds (User, Group, Component, …), breaking SSO.
-        # TODO: remove once ai-model-server plugin is fixed upstream to use addProcessor.
-        - name: patch-catalog-models
-          image: '{{ include "backstage.image" . }}'
-          command: ['sh', '-c']
-          args:
-            - |
-              PLUGIN_DIR=$(find /dynamic-plugins-root -maxdepth 1 -name '*ai-model-server*' -type d | head -1)
-              if [ -z "$PLUGIN_DIR" ]; then
-                echo 'ai-model-server plugin not found, skipping patch'
-                exit 0
-              fi
-              echo "Patching $PLUGIN_DIR/dist/module.cjs.js to add default entity models..."
-              cat > "$PLUGIN_DIR/dist/module.cjs.js" << 'PATCH_EOF'
-              'use strict';
-              var backendPluginApi = require('@backstage/backend-plugin-api');
-              var alpha = require('@backstage/plugin-catalog-node/alpha');
-              var backstagePluginCatalogModelAiModelServer = require('@red-hat-developer-hub/backstage-plugin-catalog-model-ai-model-server');
-              var catalogModelAlpha = require('@backstage/catalog-model/alpha');
-              const catalogModuleAiModelServer = backendPluginApi.createBackendModule({
-                pluginId: "catalog",
-                moduleId: "ai-model-server",
-                register(reg) {
-                  reg.registerInit({
-                    deps: { model: alpha.catalogModelExtensionPoint },
-                    async init({ model }) {
-                      model.addModelSource({
-                        async *read() {
-                          yield { data: [
-                            { layer: catalogModelAlpha.defaultCatalogEntityModel },
-                            { layer: catalogModelAlpha.aiResourceEntityModel },
-                            { layer: backstagePluginCatalogModelAiModelServer.aiModelServerApiEntityModel }
-                          ] };
-                        }
-                      });
-                    }
-                  });
-                }
-              });
-              exports.catalogModuleAiModelServer = catalogModuleAiModelServer;
-              PATCH_EOF
-              echo 'Patch applied successfully.'
-          imagePullPolicy: Always
-          volumeMounts:
-            - mountPath: /dynamic-plugins-root
-              name: dynamic-plugins-root
         - name: byok-rag-init
           image: quay.io/redhat-ai-dev/byok-sample:latest
           imagePullPolicy: Always

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -277,10 +277,12 @@ backstage:
                   redirects:
                     - from: /
                       to: /home
-            # Disable homepage widgets that require the visits API (page tracking analytics)
+            # Disable homepage widgets and visit tracking infrastructure
             # to avoid "Something Went Wrong" error boxes on the home page
             - home-page-widget:home/recently-visited: false
             - home-page-widget:home/top-visited: false
+            - api:home/visits: false
+            - app-root-element:home/visit-listener: false
           analytics:
             adoptionInsights:
               maxBufferSize: 20

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -548,6 +548,54 @@ backstage:
               subPath: .npmrc
             - mountPath: /extensions
               name: extensions-catalog
+        # Patch ai-model-server to also register default + AiResource entity models.
+        # Without this, the ModelProcessor only knows AiModelServerAPI and rejects
+        # all standard entity kinds (User, Group, Component, …), breaking SSO.
+        # TODO: remove once ai-model-server plugin is fixed upstream to use addProcessor.
+        - name: patch-catalog-models
+          image: '{{ include "backstage.image" . }}'
+          command: ['sh', '-c']
+          args:
+            - |
+              PLUGIN_DIR=$(find /dynamic-plugins-root -maxdepth 1 -name '*ai-model-server*' -type d | head -1)
+              if [ -z "$PLUGIN_DIR" ]; then
+                echo 'ai-model-server plugin not found, skipping patch'
+                exit 0
+              fi
+              echo "Patching $PLUGIN_DIR/dist/module.cjs.js to add default entity models..."
+              cat > "$PLUGIN_DIR/dist/module.cjs.js" << 'PATCH_EOF'
+              'use strict';
+              var backendPluginApi = require('@backstage/backend-plugin-api');
+              var alpha = require('@backstage/plugin-catalog-node/alpha');
+              var backstagePluginCatalogModelAiModelServer = require('@red-hat-developer-hub/backstage-plugin-catalog-model-ai-model-server');
+              var catalogModelAlpha = require('@backstage/catalog-model/alpha');
+              const catalogModuleAiModelServer = backendPluginApi.createBackendModule({
+                pluginId: "catalog",
+                moduleId: "ai-model-server",
+                register(reg) {
+                  reg.registerInit({
+                    deps: { model: alpha.catalogModelExtensionPoint },
+                    async init({ model }) {
+                      model.addModelSource({
+                        async *read() {
+                          yield { data: [
+                            { layer: catalogModelAlpha.defaultCatalogEntityModel },
+                            { layer: catalogModelAlpha.aiResourceEntityModel },
+                            { layer: backstagePluginCatalogModelAiModelServer.aiModelServerApiEntityModel }
+                          ] };
+                        }
+                      });
+                    }
+                  });
+                }
+              });
+              exports.catalogModuleAiModelServer = catalogModuleAiModelServer;
+              PATCH_EOF
+              echo 'Patch applied successfully.'
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /dynamic-plugins-root
+              name: dynamic-plugins-root
         - name: byok-rag-init
           image: quay.io/redhat-ai-dev/byok-sample:latest
           imagePullPolicy: Always

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -54,7 +54,7 @@ global:
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-agent:bs_1.52.0__0.4.0
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:pr_3227__0.4.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:pr_3293__0.5.0
         disabled: false
 
       # Boost Plugins

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -81,6 +81,11 @@ global:
       # Home page (NFS / route)
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-home:bs_1.52.0__0.9.7
         disabled: false
+      # RHDH Homepage (customized home page with widgets + root redirect)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__1.17.0
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.52.0__0.4.0
+        disabled: false
 
       # Global Header
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header:bs_1.52.0__2.0.0

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -476,6 +476,153 @@ backstage:
               target: "https://news.mit.edu/topic/mitartificial-intelligence2-rss.xml"
               changeOrigin: true
               followRedirects: true
+        boost:
+          security:
+            mode: 'development-only-no-auth'
+            adminUsers:
+              - 'user:default/admin'
+              - 'user:default/guest'
+          entityProviders:
+            ogx:
+              baseUrl: ${BOOST_OGX_URL:-http://localhost:8321}
+              defaultAgent: router
+              maxAgentTurns: 10
+              agents:
+                - id: router
+                  name: FantaCo Router
+                  description: Customer service router that classifies and transfers to specialists
+                  instructions: |
+                    You are a customer service router for FantaCo. Classify the user's
+                    question and transfer to the appropriate specialist agent.
+
+                    Transfer rules:
+                    - Legal questions (software licenses, embargoes, privacy/PII,
+                      contracts, policies, compliance) -> transfer to Legal
+                    - Technical support (OpenShift/Kubernetes, deployment, permissions,
+                      performance, FantaCo products like CloudSync or TechGear Pro,
+                      troubleshooting) -> transfer to Software Support
+                    - HR questions (benefits, health care, vacation/PTO, retirement,
+                      workspaces, office facilities, bonuses, compensation, perks,
+                      participation requirements) -> transfer to Human Resources.
+                      If the question mentions "workspaces at FantaCo", ALWAYS transfer
+                      to Human Resources.
+                    - Sales questions (territories, leads, discounting, quotas, CRM,
+                      brand guidelines, expenses, escalations, performance metrics)
+                      -> transfer to Sales
+                    - Procurement questions (competitive bidding, vendor evaluation,
+                      ethics, transparency, spending limits, approval processes)
+                      -> transfer to Procurement
+
+                    Always transfer to the most appropriate specialist. Do not answer
+                    the question yourself.
+                  handoffs:
+                    - legal
+                    - support
+                    - hr
+                    - sales
+                    - procurement
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+                - id: legal
+                  name: Legal
+                  description: Handles questions about software licenses, embargoes, privacy/PII, contracts, policies, procedures, or compliance
+                  handoffDescription: Handles questions about software licenses, embargoes, privacy/PII, contracts, policies, procedures, or compliance
+                  instructions: |
+                    You are FantaCo's Legal department specialist. Based on the relevant
+                    documents in the knowledge base, help with the user's legal query.
+                    Provide a helpful response based on the documents found. If no
+                    relevant documents are found, provide general guidance.
+                  enableRAG: true
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+                - id: support
+                  name: Software Support
+                  description: Handles technical support questions about OpenShift/Kubernetes, deployment, permissions, performance, and FantaCo products
+                  handoffDescription: Handles technical support questions about OpenShift/Kubernetes, application deployment, permissions, resource utilization, performance, and FantaCo products (CloudSync, TechGear Pro)
+                  instructions: |
+                    You are FantaCo's Software Support specialist. Based on the relevant
+                    documents in the knowledge base, help with the user's technical
+                    support query. Provide a helpful response based on the documents
+                    found. If no relevant documents are found, provide general guidance.
+                  enableRAG: true
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+                - id: hr
+                  name: Human Resources
+                  description: Handles questions about employee benefits, health care, vacation/PTO, retirement, workspaces, and compensation
+                  handoffDescription: Handles questions about employee benefits, health care, vacation/PTO, retirement plans, workspaces, office facilities, work environment, bonuses, compensation, and perks
+                  instructions: |
+                    You are FantaCo's Human Resources specialist. Based on the relevant
+                    documents in the knowledge base, help with the user's HR query.
+
+                    FantaCo's benefits are organized into categories:
+                    - bare necessities: workspace, health care, vacation/PTO, retirement
+                    - beyond the basics: music, parties, activities, food services,
+                      driving services, bonuses
+                    - caveats: participation requirements
+
+                    Try to narrow the response to details from the relevant sub-section
+                    of the benefits document when possible.
+
+                    Provide a helpful response based on the documents found. If no
+                    relevant documents are found, provide general guidance.
+                  enableRAG: true
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+                - id: sales
+                  name: Sales
+                  description: Handles questions about sales territories, leads, discounting, quotas, CRM, and performance metrics
+                  handoffDescription: Handles questions about sales territories, lead assignments, discounting, deal approval, quotas, sales compensation, CRM systems, brand guidelines, expenses, escalations, and performance metrics
+                  instructions: |
+                    You are FantaCo's Sales specialist. Based on the relevant documents
+                    in the knowledge base, help with the user's sales query.
+
+                    FantaCo's sales operation manual covers:
+                    - geographic territories
+                    - lead assignments
+                    - discounting and deal approval
+                    - quotas and compensation
+                    - CRM systems
+                    - brands and communications
+                    - expenses and escalations
+                    - performance and compliance
+
+                    Try to narrow the response to details from the relevant sub-section
+                    of the sales document when possible.
+
+                    Provide a helpful response based on the documents found. If no
+                    relevant documents are found, provide general guidance.
+                  enableRAG: true
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+                - id: procurement
+                  name: Procurement
+                  description: Handles questions about competitive bidding, vendor evaluation, procurement ethics, and approval processes
+                  handoffDescription: Handles questions about competitive bidding, vendor evaluation, procurement ethics, transparency, spending limits, and approval processes
+                  instructions: |
+                    You are FantaCo's Procurement specialist. Based on the relevant
+                    documents in the knowledge base, help with the user's procurement
+                    query.
+
+                    FantaCo's procurement policies cover:
+                    - competitive bidding
+                    - vendor evaluation and categorization
+                    - ethics and transparency
+                    - review processes
+                    - spending limits
+
+                    Try to narrow the response to details from the relevant sub-section
+                    of the procurement document when possible.
+
+                    Provide a helpful response based on the documents found. If no
+                    relevant documents are found, provide general guidance.
+                  enableRAG: true
+                  model: ${BOOST_MODEL:-}
+                  lifecycleStage: published
+          providers:
+            ogx:
+              baseUrl: ${BOOST_OGX_URL:-http://localhost:8321}
+              defaultModel: ${BOOST_MODEL:-default}
       readinessProbe:
         failureThreshold: 3
         httpGet:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -24,6 +24,8 @@ global:
 
       ##### Red Hat Plugins #####
       # ArgoCD (frontend disabled — no NFS version yet; backends kept)
+      # TODO: re-enable when https://github.com/backstage/community-plugins/pull/10112 merges
+      # and updated dynamic plugin images are available for argocd and argocd-backend
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.49.4__2.8.0
         disabled: true
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.49.4__4.8.0

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -89,6 +89,23 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs:bs_1.52.0__1.17.7
         disabled: false
 
+      # Disable dist wrappers replaced by OCI images above
+      # (these are enabled by dynamic-plugins.default.yaml and must be explicitly disabled)
+      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
+        disabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+        disabled: true
+
       # Gitlab Plugins
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
         disabled: false
@@ -98,7 +115,7 @@ global:
         disabled: true
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
         disabled: true
-        
+
       # Github Plugins
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
         disabled: false
@@ -479,7 +496,7 @@ backstage:
                   - ReadWriteOnce
                 resources:
                   requests:
-                    storage: 2Gi
+                    storage: 4Gi
         - name: dynamic-plugins
           configMap:
             defaultMode: 420

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -66,7 +66,7 @@ global:
         disabled: false
 
       # Model Catalog Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog:bs_1.52.0__0.10.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog:bs_1.52.0__1.0.0
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend:bs_1.52.0__0.6.0
         disabled: false

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -245,6 +245,10 @@ backstage:
         app:
           title: AI Rolling Demo Developer Hub
           baseUrl: "${RHDH_BASE_URL}"
+          extensions:
+            - page:home/home:
+                config:
+                  path: /
           analytics:
             adoptionInsights:
               maxBufferSize: 20

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -282,7 +282,7 @@ backstage:
       image:
         registry: quay.io
         repository: rhdh/rhdh-hub-rhel9
-        tag: "1.10-164"
+        tag: "2.0-61"
         pullSecrets:
           - quay-pull-secret
       command: []

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -18,6 +18,10 @@ global:
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-theme:bs_1.52.0__1.0.2
         disabled: false
 
+      # OAuth2 callback handler (may provide /oauth2/* route for OIDC flow)
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.52.0__0.1.9
+        disabled: false
+
       ##### Red Hat Plugins #####
       # ArgoCD (frontend disabled — no NFS version yet; backends kept)
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.49.4__2.8.0

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -323,6 +323,10 @@ backstage:
               - host: '*.mozilla.org'
               - host: '*.openshift.com'
               - host: '*.openshiftapps.com'
+        techdocs:
+          builder: local
+          generator:
+            runIn: local
         signInPage: oidc
         catalog:
           rules:
@@ -345,7 +349,13 @@ backstage:
               rules:
                 - allow: [Component, System]
           providers:
-            modelCatalog: {}
+            modelCatalog:
+              kserve-kubeflow-connector:
+                cluster-1:
+                  name: my-k8s-cluster
+                  kubeflow-model-catalog-url: '${KUBEFLOW_MODEL_CATALOG_URL:-}'
+                  default-owner: '${OWNER:-default-owner}'
+                  default-lifecycle: '${LIFECYCLE:-production}'
             github:
               providerId:
                 organization: "${GITOPS_GIT_ORG}"

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -246,7 +246,7 @@ backstage:
           title: AI Rolling Demo Developer Hub
           baseUrl: "${RHDH_BASE_URL}"
           extensions:
-            - page:home/home:
+            - page:home:
                 config:
                   path: /
           analytics:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -56,7 +56,7 @@ global:
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-agent:bs_1.52.0__0.4.0
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:pr_3293__0.5.0
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-ai-resource-extensions:bs_1.52.0__0.5.0
         disabled: false
 
       # Boost Plugins

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -246,9 +246,11 @@ backstage:
           title: AI Rolling Demo Developer Hub
           baseUrl: "${RHDH_BASE_URL}"
           extensions:
-            - page:home:
+            - app/routes:
                 config:
-                  path: /
+                  redirects:
+                    - from: /
+                      to: /home
           analytics:
             adoptionInsights:
               maxBufferSize: 20

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -4,6 +4,16 @@ global:
     includes:
       - "dynamic-plugins.default.yaml"
     plugins:
+      ##### Custom sign in page plugin (now NFS compatible) #####
+      - package: oci://quay.io/redhat-ai-dev/rolling-demo-customized-sign-in-page:0.2.0!red-hat-developer-hub-backstage-plugin-rolling-demo-customized-sign-in-page
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-rolling-demo-customized-sign-in-page:
+                signInPage:
+                  importName: RollingDemoCustomizedSignInPage
+
       ##### NFS Frontend Plugins #####
       # App Auth (NFS sign-in page, replaces custom sign-in page)
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-app-auth:bs_1.52.0__0.1.0

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -121,6 +121,12 @@ export NOTEBOOKS_QUERY_PROVIDER_ID="vllm"
 # from the kserve deployment name or vLLM model path. It takes values similar to VALIDATION_MODEL_NAME.
 export NOTEBOOKS_QUERY_MODEL="llama-31-8b-version1"
 
+# Boost / OGX (AI Catalog agent chat)
+# BOOST_OGX_URL: the URL of the OGX service backing the Boost agent chat.
+export BOOST_OGX_URL="http://ogx-service:8321"
+# BOOST_MODEL: the LLM model name used by Boost agents. Leave empty to use the OGX default.
+export BOOST_MODEL=""
+
 # Postgres secrets
 export LIGHTSPEED_POSTGRES_PASSWORD="your-preffered-lightspeed-psql-password"
 export LIGHTSPEED_POSTGRES_USER="your-preffered-lightspeed-psql-username"

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -217,7 +217,7 @@ export K8S_CA_DATA=""
 
 The `setup.sh` script automates the entire setup process by calling focused subscripts in order:
 
-1. [`install-operators.sh`](../scripts/install-operators.sh) — installs the required operators (OpenShift GitOps, OpenShift Pipelines, Node Feature Discovery, NVIDIA GPU) and creates the NFD instance and NVIDIA ClusterPolicy. Skipped for NFD and GPU when `SKIP_RHOAI_SETUP=true`.
+1. [`install-operators.sh`](../scripts/install-operators.sh) — installs the required operators (OpenShift GitOps, OpenShift Pipelines, Node Feature Discovery, NVIDIA GPU) and creates the NFD instance and NVIDIA ClusterPolicy. Skipped for NFD and GPU when `SKIP_GPU_SETUP=true` or `SKIP_RHOAI_SETUP=true`.
 2. [`setup-rhoai.sh`](../scripts/setup-rhoai.sh) — applies the ODH Kubeflow Model Registry kustomize and waits for the setup job to complete.
 3. [`setup-argocd.sh`](../scripts/setup-argocd.sh) — retrieves ArgoCD admin credentials and generates an API token.
 4. [`setup-namespaces.sh`](../scripts/setup-namespaces.sh) — creates the RHDH and LightSpeed Postgres namespaces.
@@ -231,6 +231,7 @@ The `setup.sh` script automates the entire setup process by calling focused subs
 You can skip earlier steps if they have already been completed on your cluster:
 
 - `SKIP_INSTALL_DEPS=true` — skips all operator and instance installation.
+- `SKIP_GPU_SETUP=true` — skips NFD and GPU operator installation. RHOAI setup still runs unless `SKIP_RHOAI_SETUP` is also set.
 - `SKIP_RHOAI_SETUP=true` — skips NFD + GPU operator installation and RHOAI setup. When used alone (as in `make install-no-rhoai`), also disables Model Catalog RBAC in the deployed chart.
 - `RHOAI_PREINSTALLED=true` — used together with `SKIP_RHOAI_SETUP=true`. Skips RHOAI setup but keeps Model Catalog RBAC enabled and connects to an existing RHOAI instance via the `kserve-kubeflow-connector` plugin. This is what `make install-kserve-catalog-bridge-rhoai-handled-separately` sets.
 
@@ -281,6 +282,7 @@ The following variables have built-in defaults and do not need to be set in `pri
 | `GPU_STARTING_CSV`              | `gpu-operator-certified.v25.10.1`         | Starting CSV for the NVIDIA GPU operator.                                                                                                                                        |
 | `K8S_SA_TOKEN`                  | auto-resolved                             | Service account token for KServe access. Auto-resolved from the `rhdh-rhoai-bridge-token` secret if left empty. Used by `make install` and `make install-kserve-catalog-bridge-rhoai-handled-separately`. |
 | `K8S_CA_DATA`                   | auto-resolved                             | Base64-encoded CA certificate for the cluster API. Auto-resolved from the `rhdh-rhoai-bridge-token` secret if left empty. Used by `make install` and `make install-kserve-catalog-bridge-rhoai-handled-separately`. |
+| `SKIP_GPU_SETUP`                | `false`                                   | Skip NFD and NVIDIA GPU operator installation. RHOAI setup still runs unless `SKIP_RHOAI_SETUP` is also set. Useful for clusters without GPU nodes that still need RHOAI for non-inference workloads. |
 
 These can be set in `private-env` or passed directly on the command line:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,6 +43,10 @@ export VALIDATION_MODEL_NAME="<model>"
 export NOTEBOOKS_QUERY_PROVIDER_ID="<provider-id>"
 export NOTEBOOKS_QUERY_MODEL="<model>"
 
+# Boost / OGX (AI Catalog agent chat)
+export BOOST_OGX_URL="<ogx-url>"
+export BOOST_MODEL="<model-name>"
+
 # Lightspeed PostgreSQL
 export LIGHTSPEED_POSTGRES_USER="<user>"
 export LIGHTSPEED_POSTGRES_PASSWORD="<password>"

--- a/scripts/apply-argocd-application.sh
+++ b/scripts/apply-argocd-application.sh
@@ -9,8 +9,6 @@ source "$SCRIPTS_DIR/common.sh"
 apply_argocd_application() {
   log "Applying gitops/application.yaml..."
   cd "$GITOPS_DIR" || { log "Failed to cd into $GITOPS_DIR. Exiting."; log_fail; exit 1; }
-  local openshift_ai_url="https://rhods-dashboard-redhat-ods-applications.${RHDH_CLUSTER_ROUTER_BASE}/"
-  local openshift_ai_param="global.dynamic.plugins[11].pluginConfig.dynamicPlugins.frontend.red-hat-developer-hub\\.backstage-plugin-global-header.mountPoints[13].config.props.link"
   local rhdh_namespace="${RHDH_NAMESPACE:-rolling-demo-ns}"
   local argocd_app_name="${ARGOCD_APP_NAME:-rolling-demo}"
   if oc get application "$argocd_app_name" -n openshift-gitops >/dev/null 2>&1; then
@@ -28,8 +26,7 @@ apply_argocd_application() {
   else
     helm_params="[
        {\"name\": \"global.clusterRouterBase\", \"value\": \"$RHDH_CLUSTER_ROUTER_BASE\"},
-       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"},
-       {\"name\": \"$openshift_ai_param\", \"value\": \"$openshift_ai_url\"}
+       {\"name\": \"global.isSecondaryInstance\", \"value\": \"${IS_SECONDARY_INSTANCE:-false}\"}
      ]"
   fi
   if ! yq eval \

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -132,12 +132,14 @@ kubectl exec -n "$LIGHTSPEED_POSTGRES_NAMESPACE" deploy/postgres -- \
 
 # initial installation of rhdh-chart provided our ci values
 log "Installing RHDH chart via Helm..."
+# Disable plugins that aren't needed for CI/kind environments.
+# NOTE: If the dynamic plugins list in values.yaml changes, these indices may need adjustment.
+# Current: plugins[12] = scaffolder-mcp-extras
 helm install "$ARGOCD_APP_NAME" "$GITOPS_DIR/charts/rhdh" \
   --namespace "$RHDH_NAMESPACE" \
   -f "$GITOPS_DIR/charts/rhdh/values.yaml" \
   -f "$GITOPS_DIR/ci/values-ci.yaml" \
-  --set 'global.dynamic.plugins[8].disabled=true' \
-  --set 'global.dynamic.plugins[9].disabled=true' \
+  --set 'global.dynamic.plugins[12].disabled=true' \
   --timeout 40m \
   --wait
 

--- a/scripts/env
+++ b/scripts/env
@@ -73,6 +73,11 @@ export KUBEFLOW_MODEL_CATALOG_URL=
 export BOOST_OGX_URL=
 export BOOST_MODEL=
 
+# GPU Setup (NFD + NVIDIA GPU Operator)
+# Set to "true" to skip Node Feature Discovery and NVIDIA GPU operator installation
+# while still allowing RHOAI setup. RHOAI can run without GPU for non-inference workloads.
+export SKIP_GPU_SETUP=
+
 # Postgres secrets
 export LIGHTSPEED_POSTGRES_PASSWORD=
 export LIGHTSPEED_POSTGRES_USER=

--- a/scripts/env
+++ b/scripts/env
@@ -69,6 +69,10 @@ export K8S_CA_DATA=
 # Auto-resolved from the rhoai-model-registries namespace route or service.
 export KUBEFLOW_MODEL_CATALOG_URL=
 
+# Boost / OGX secrets (for AI Catalog agent chat)
+export BOOST_OGX_URL=
+export BOOST_MODEL=
+
 # Postgres secrets
 export LIGHTSPEED_POSTGRES_PASSWORD=
 export LIGHTSPEED_POSTGRES_USER=

--- a/scripts/install-operators.sh
+++ b/scripts/install-operators.sh
@@ -277,8 +277,8 @@ install_deps() {
     wait_for_csv "$PIPELINES_OPERATOR_NAMESPACE" "$PIPELINES_OPERATOR_PACKAGE"
   fi
 
-  if [[ "${SKIP_RHOAI_SETUP:-}" == "true" ]]; then
-    log "SKIP_RHOAI_SETUP=true — skipping NFD and GPU operator installation."
+  if [[ "${SKIP_GPU_SETUP:-}" == "true" || "${SKIP_RHOAI_SETUP:-}" == "true" ]]; then
+    log "Skipping NFD and GPU operator installation (SKIP_GPU_SETUP=${SKIP_GPU_SETUP:-false}, SKIP_RHOAI_SETUP=${SKIP_RHOAI_SETUP:-false})."
   else
     # install Node Feature Discovery Operator if it doesn't exist
     if check_operator_exists "$NFD_OPERATOR_NAMESPACE" "$NFD_OPERATOR_PACKAGE"; then


### PR DESCRIPTION

[kubeflow-model-catalog-notes.txt](https://github.com/user-attachments/files/31198328/kubeflow-model-catalog-notes.txt)
## What does this PR do?

- Moves the RHDH version of the dev instance to 2.x
- disable argocd since it is not NFS ready (upstream PR in progress)
- moves other frontend plugis to a level which supports NFS
- brings in the boost frontend
- brings in the new model catalog plugins
- brings in our catalog extensions for various AI related entity kinds
- removes the model catalog bridge sidecar containers

### Which issue(s) does this PR fix

https://redhat.atlassian.net/browse/RHIDP-15537 

### How to test changes / Special notes to the reviewer

running either `make install` or `make install-kserve-catalog-bridge-rhoai-handled-separately` will install ... the later allows for you installing RHOAI before running our make

also, thanks to @rajin-kichannagari  we now have sufficient Kserve samples that allow us to deploy a running Inference service without GPU

```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  name: mlserver-runtime
  annotations:
    opendatahub.io/runtime-version: 1.7.1
    openshift.io/display-name: MLServer ServingRuntime for KServe
    serving.kserve.io/server-type: mlserver
  labels:
    opendatahub.io/dashboard: "true"
spec:
  annotations:
    monitoring.opendatahub.io/scrape: "true"
    opendatahub.io/kserve-runtime: mlserver
    prometheus.io/path: /metrics
    prometheus.io/port: "8082"
  containers:
  - env:
    - name: MLSERVER_MODEL_IMPLEMENTATION
      value: '{{.Labels.modelClass}}'
    - name: MLSERVER_HTTP_PORT
      value: "8080"
    - name: MLSERVER_MODELS_DIR
      value: /mnt/models
    image: registry.redhat.io/rhoai/odh-mlserver-rhel9@sha256:ebb3fe12eb37c4fed6bce99a58e31bb6df37c4183166b8ae6e85f6c22a29b92c
    livenessProbe:
      failureThreshold: 6
      httpGet:
        path: /v2/models/{{.Name}}/ready
        port: 8080
      initialDelaySeconds: 20
      periodSeconds: 10
      timeoutSeconds: 5
    name: kserve-container
    ports:
    - containerPort: 8080
      protocol: TCP
    readinessProbe:
      failureThreshold: 3
      httpGet:
        path: /v2/models/{{.Name}}/ready
        port: 8080
      initialDelaySeconds: 5
      periodSeconds: 5
      timeoutSeconds: 5
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      privileged: false
      runAsNonRoot: true
    startupProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - |
          [ -n "$(ls -A /mnt/models 2>/dev/null)" ]
      failureThreshold: 1
      initialDelaySeconds: 1
      periodSeconds: 1
  multiModel: false
  protocolVersions:
  - v2
  supportedModelFormats:
  - name: sklearn
    version: "0"
    autoSelect: true
  - name: sklearn
    version: "1"
    autoSelect: true
  - name: xgboost
    version: "1"
    autoSelect: true
  - name: xgboost
    version: "2"
    autoSelect: true
  - name: lightgbm
    version: "3"
    autoSelect: true
  - name: lightgbm
    version: "4"
    autoSelect: true
  - name: onnx
    version: "1"
    autoSelect: true                                                                                                                                                                                                                                                                                                                                      
```

```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: sklearn-iris
  # namespace: default
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      protocolVersion: v2
      runtime: mlserver-runtime
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
```

and if you are really curious (though not required)

```
!/bin/bash

NAMESPACE="${1:-ggmtest}"
SERVICE_NAME="sklearn-iris"
URL="http://${SERVICE_NAME}-predictor.${NAMESPACE}.svc.cluster.local:8080/v2/models/${SERVICE_NAME}/infer"

kubectl run curl-test --rm -i --restart=Never --image=curlimages/curl -n "$NAMESPACE" -- \
  curl -s -X POST "$URL" \
  -H "Content-Type: application/json" \
  -d '{"inputs": [{"name": "input-0", "shape": [2, 4], "datatype": "FP32", "data": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}]}'

```
