### PR TITLE
feat(okp): add vendored OKP subchart for lightspeed

### DIFF
--- a/charts/rhdh/Chart.yaml
+++ b/charts/rhdh/Chart.yaml
@@ -8,3 +8,6 @@ dependencies:
   - name: backstage
     repository: https://redhat-developer.github.io/rhdh-chart/
     version: "7.0.1"
+  - name: okp
+    version: "0.1.0"
+    condition: okp.enabled

--- a/charts/rhdh/charts/okp/Chart.yaml
+++ b/charts/rhdh/charts/okp/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: okp
+description: Red Hat Offline Knowledge Portal (OKP) Helm chart for OpenShift
+type: application
+version: 0.1.0
+appVersion: "1.0"
+keywords:
+  - okp
+  - offline-knowledge-portal
+  - solr
+  - red-hat
+  - openshift
+sources:
+  - https://github.com/redhat-developer/rhdh-chart

--- a/charts/rhdh/charts/okp/templates/_helpers.tpl
+++ b/charts/rhdh/charts/okp/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/*
+Return the OKP deployment/service/route/ingress name.
+Mirrors rhdh.lightspeed.okp.fullname from rhdh-chart.
+*/}}
+{{- define "okp.fullname" -}}
+{{- printf "%s-lightspeed-okp" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return OKP labels. Mirrors rhdh.lightspeed.okp.labels.
+*/}}
+{{- define "okp.labels" -}}
+app.kubernetes.io/name: lightspeed-okp
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: lightspeed-okp
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Return OKP selector labels. Mirrors rhdh.lightspeed.okp.selectorLabels.
+*/}}
+{{- define "okp.selectorLabels" -}}
+app.kubernetes.io/name: lightspeed-okp
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/rhdh/charts/okp/templates/deployment.yaml
+++ b/charts/rhdh/charts/okp/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "okp.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "okp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "okp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "okp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: okp
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            /opt/solr/bin/solr start --user-managed --force -m {{ .Values.solr.memory }}
+            rm -f /etc/httpd/conf.d/ssl.conf
+            exec httpd -D FOREGROUND
+        env:
+        - name: SOLR_HOST_BIND
+          value: {{ .Values.solr.hostBind | quote }}
+        - name: MIMIR_HTTPD_SERVER_NAME
+          value: {{ .Values.httpd.serverName | quote }}
+        - name: COMPRESSED
+          value: {{ .Values.httpd.compressed | quote }}
+        - name: ENCRYPT
+          value: {{ .Values.httpd.encrypt | quote }}
+        ports:
+        - containerPort: 8080
+          name: httpd
+          protocol: TCP
+        - containerPort: 8983
+          name: solr
+          protocol: TCP
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}

--- a/charts/rhdh/charts/okp/templates/route.yaml
+++ b/charts/rhdh/charts/okp/templates/route.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "okp.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "okp.labels" . | nindent 4 }}
+spec:
+  to:
+    kind: Service
+    name: {{ include "okp.fullname" . }}
+  port:
+    targetPort: httpd
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+{{- end }}

--- a/charts/rhdh/charts/okp/templates/service.yaml
+++ b/charts/rhdh/charts/okp/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "okp.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "okp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: httpd
+  - port: 8983
+    targetPort: 8983
+    name: solr
+  selector:
+    {{- include "okp.selectorLabels" . | nindent 4 }}

--- a/charts/rhdh/charts/okp/values.yaml
+++ b/charts/rhdh/charts/okp/values.yaml
@@ -1,0 +1,49 @@
+# OKP (Offline Knowledge Portal) vendored subchart.
+# YAMLs mirror the golden reference in rhdh-chart PR #500
+# (charts/backstage/templates/lightspeed/okp-*.yaml).
+image:
+  # -- OKP container image repository.
+  repository: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9
+  # -- OKP container image pull policy.
+  pullPolicy: IfNotPresent
+  # -- OKP container image tag.
+  tag: "1.2.10-1786628394"
+# -- Number of OKP replicas.
+replicaCount: 1
+solr:
+  # -- Solr JVM memory allocation.
+  memory: "1g"
+  # -- Solr host bind address.
+  hostBind: "0.0.0.0"
+httpd:
+  # -- HTTPD server name.
+  serverName: "localhost"
+  # -- Enable gzip compression in HTTPD.
+  compressed: "true"
+  # -- Enable HTTPS encryption in HTTPD.
+  encrypt: "false"
+# -- Resource requests/limits for the OKP container.
+resources:
+  requests:
+    cpu: "200m"
+    memory: "2Gi"
+  limits:
+    cpu: "2"
+    memory: "4Gi"
+service:
+  # -- OKP Service type.
+  type: ClusterIP
+# -- Image pull secrets for the OKP container image.
+# Required on vanilla Kubernetes to authenticate with registry.redhat.io.
+# Not needed on OpenShift where the cluster-wide pull secret covers Red Hat registries.
+imagePullSecrets: []
+# imagePullSecrets:
+#   - "my-rh-registry-secret"
+route:
+  # -- Enable OpenShift Route for OKP.
+  enabled: true
+  tls:
+    # -- TLS termination type for the OKP route.
+    termination: edge
+    # -- Insecure edge termination policy.
+    insecureEdgeTerminationPolicy: Allow

--- a/charts/rhdh/templates/lightspeed-stack-config.yaml
+++ b/charts/rhdh/templates/lightspeed-stack-config.yaml
@@ -162,6 +162,6 @@ data:
         - custom-org-docs
         - okp
     okp:
-      rhokp_url: '${env.OKP_SERVICE_URL:=http://localhost:8080}'
+      rhokp_url: '${env.OKP_SERVICE_URL:=http://{{ .Release.Name }}-lightspeed-okp-{{ .Release.Namespace }}.{{ .Values.global.clusterRouterBase }}}'
       offline: true
       chunk_filter_query: 'product:*developer_hub*'

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -216,6 +216,11 @@ global:
       env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /app-root/gcp-creds.json
+        # Redirect the HuggingFace/sentence-transformers cache into the writable
+        # /tmp emptyDir. Required because the sidecar runs readOnlyRootFilesystem:true;
+        # without this, embedding model loading fails writing to ~/.cache. Mirrors rhdh-chart.
+        - name: HF_HOME
+          value: /tmp/hf_cache
     configMaps:
       - name: stack
         create: false
@@ -690,4 +695,8 @@ backstage:
       destinationCACertificate: ""
       insecureEdgeTerminationPolicy: "Redirect"
 rhoai:
+  enabled: true
+# OKP (Offline Knowledge Portal) vendored subchart — see charts/rhdh/charts/okp.
+# Defaults (pinned image, route/ingress, resources) live in the subchart values.yaml.
+okp:
   enabled: true


### PR DESCRIPTION

## What does this PR do?

<!-- _Summarize the changes_ -->
Add Offline Knowledge Portal (OKP) as a self-contained vendored subchart under charts/rhdh/charts/okp, mirroring the rhdh-chart OKP templates (Deployment/Service/Route) with the pinned image
registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:1.2.10-1786628394.

- Enable via okp.enabled condition on the umbrella chart
- OpenShift-only: Route gated on route.enabled (no Ingress / capability logic)
- Wire OKP_SERVICE_URL default to the computed OKP Route URL in lightspeed-stack-config
- Set HF_HOME=/tmp/hf_cache on the LCORE sidecar (readOnlyRootFilesystem)

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->
https://redhat.atlassian.net/browse/RHIDP-14135

### How to test changes / Special notes to the reviewer

<!-- _Provide information to the reviewer_ -->
make install-no-rhoai