### PR TITLE
fix(okp): address PR #307 review — remove okp.enabled, imagePullSecre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The rolling demo combines the following components so far:
 - The [Model Catalog Bridge](https://github.com/redhat-ai-dev/model-catalog-bridge) and the [catalog-backend-module-rhdh-ai](https://github.com/redhat-ai-dev/rhdh-plugins/tree/main/workspaces/rhdh-ai/plugins/catalog-backend-module-rhdh-ai) plugin. This mechanism provides a way to facilitate the seamless export of AI model records from Red Hat OpenShift AI and imports them into Red Hat Developer Hub (Backstage) as catalog entities.
 - The [MCP Plugins](https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/mcp-integrations), which provides a way for LLMs and AI applications to interact with Developer Hub.
 - `Red Hat Developer Lightspeed` (Developer Lightspeed) is a virtual assistant powered by generative AI that offers in-depth insights into `Red Hat Developer Hub` (RHDH), including its wide range of capabilities.
+- The [Red Hat Offline Knowledge Portal](https://access.redhat.com/products/red-hat-offline-knowledge-portal/) (OKP), deployed as a vendored Helm subchart, provides offline Red Hat product documentation search for the Intelligent Assistant.
 
 ## Capabilities & Limitations
 
@@ -53,8 +54,8 @@ Two install paths are available:
 
 | Command                 | Cluster requirements                     | What's included                                                                |
 | ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------------ |
-| `make install`          | GPU-capable nodes (`g5.2xlarge`+), RHOAI | Full stack: RHDH, Lightspeed, Model Catalog Bridge, AI Software Templates      |
-| `make install-no-rhoai` | Any OCP cluster (no GPU required)        | RHDH, Lightspeed, AI Software Templates — **no** Model Catalog Bridge or RHOAI |
+| `make install`          | GPU-capable nodes (`g5.2xlarge`+), RHOAI | Full stack: RHDH, Lightspeed, OKP, Model Catalog Bridge, AI Software Templates      |
+| `make install-no-rhoai` | Any OCP cluster (no GPU required)        | RHDH, Lightspeed, OKP, AI Software Templates — **no** Model Catalog Bridge or RHOAI |
 
 Use `make install-no-rhoai` when you want to run the demo on a smaller cluster that does not have GPU nodes or Red Hat OpenShift AI.
 

--- a/charts/rhdh/Chart.yaml
+++ b/charts/rhdh/Chart.yaml
@@ -8,6 +8,7 @@ dependencies:
   - name: backstage
     repository: https://redhat-developer.github.io/rhdh-chart/
     version: "7.0.1"
+  # OKP (Offline Knowledge Portal) vendored subchart — see charts/rhdh/charts/okp.
+  # Always deployed; rolling demo requires OKP and runs OpenShift-only.
   - name: okp
     version: "0.1.0"
-    condition: okp.enabled

--- a/charts/rhdh/charts/okp/templates/deployment.yaml
+++ b/charts/rhdh/charts/okp/templates/deployment.yaml
@@ -15,12 +15,6 @@ spec:
       labels:
         {{- include "okp.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range .Values.imagePullSecrets }}
-        - name: {{ . | quote }}
-        {{- end }}
-      {{- end }}
       containers:
       - name: okp
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/rhdh/charts/okp/values.yaml
+++ b/charts/rhdh/charts/okp/values.yaml
@@ -33,12 +33,6 @@ resources:
 service:
   # -- OKP Service type.
   type: ClusterIP
-# -- Image pull secrets for the OKP container image.
-# Required on vanilla Kubernetes to authenticate with registry.redhat.io.
-# Not needed on OpenShift where the cluster-wide pull secret covers Red Hat registries.
-imagePullSecrets: []
-# imagePullSecrets:
-#   - "my-rh-registry-secret"
 route:
   # -- Enable OpenShift Route for OKP.
   enabled: true

--- a/charts/rhdh/templates/lightspeed-stack-config.yaml
+++ b/charts/rhdh/templates/lightspeed-stack-config.yaml
@@ -162,6 +162,6 @@ data:
         - custom-org-docs
         - okp
     okp:
-      rhokp_url: '${env.OKP_SERVICE_URL:=http://{{ .Release.Name }}-lightspeed-okp-{{ .Release.Namespace }}.{{ .Values.global.clusterRouterBase }}}'
+      rhokp_url: '${env.OKP_SERVICE_URL:=http://localhost:8080}'
       offline: true
       chunk_filter_query: 'product:*developer_hub*'

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -221,6 +221,13 @@ global:
         # without this, embedding model loading fails writing to ~/.cache. Mirrors rhdh-chart.
         - name: HF_HOME
           value: /tmp/hf_cache
+        # Points LCORE at the OKP service. The lightspeed-stack-config.yaml is synced
+        # from lightspeed-configs (source of truth) with a localhost default, so the
+        # cluster-specific OKP URL is injected here instead. Rendered via
+        # common.tplvalues.render (tpl), so the Helm expression resolves; the sync
+        # generator only seds the sidecar image line, leaving this env intact.
+        - name: OKP_SERVICE_URL
+          value: "http://{{ .Release.Name }}-lightspeed-okp-{{ .Release.Namespace }}.{{ .Values.global.clusterRouterBase }}"
     configMaps:
       - name: stack
         create: false
@@ -695,8 +702,4 @@ backstage:
       destinationCACertificate: ""
       insecureEdgeTerminationPolicy: "Redirect"
 rhoai:
-  enabled: true
-# OKP (Offline Knowledge Portal) vendored subchart — see charts/rhdh/charts/okp.
-# Defaults (pinned image, route/ingress, resources) live in the subchart values.yaml.
-okp:
   enabled: true


### PR DESCRIPTION


## What does this PR do?

<!-- _Summarize the changes_ -->
fix rhokp_url sync

- Remove `condition: okp.enabled` from Chart.yaml and `okp.enabled` from values.yaml — OKP always deploys on OpenShift-only rolling demo.
- Remove `imagePullSecrets` from OKP subchart (deployment + values) — not needed on OpenShift where the cluster-wide pull secret covers registry.redhat.io.
- Revert lightspeed-stack-config.yaml `rhokp_url` to the source-of-truth localhost default (file is synced/overwritten from lightspeed-configs).
- Inject `OKP_SERVICE_URL` env in sidecar env instead — tpl-rendered to the cluster-specific Route URL, survives the sync (generator only seds the sidecar image line).

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

### How to test changes / Special notes to the reviewer

<!-- _Provide information to the reviewer_ -->
