### PR TITLE
fix(gitops): mark configure-postgres-db Job for Replace on sync

### DIFF
--- a/charts/rhdh/templates/lightspeed-postgres.yaml
+++ b/charts/rhdh/templates/lightspeed-postgres.yaml
@@ -75,6 +75,8 @@ kind: Job
 metadata:
   name: configure-postgres-db
   namespace: lightspeed-postgres
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:
     spec:


### PR DESCRIPTION
Reopened from #319 as a same-repo branch so CI has access to required secrets.

## Summary
- ArgoCD syncs of `rolling-demo` fail after the first sync with `Job.batch "configure-postgres-db" is invalid: spec.template: ... field is immutable` because `Job.spec.template` cannot be patched in k8s once the Job exists.
- Adds `argocd.argoproj.io/sync-options: Replace=true` to the `configure-postgres-db` Job so ArgoCD deletes+recreates it instead of patching.

## Test plan
- [ ] Delete existing `configure-postgres-db` Job in `lightspeed-postgres` namespace on affected cluster
- [ ] Re-sync `rolling-demo` ArgoCD app, confirm sync succeeds without immutable-field error
- [ ] Confirm postgres config job completes successfully post-sync