### PR TITLE
fix(configure-postgres-db): add missing selector labels for gitops

### DIFF
--- a/charts/rhdh/templates/lightspeed-postgres.yaml
+++ b/charts/rhdh/templates/lightspeed-postgres.yaml
@@ -78,7 +78,14 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      app: postgres
   template:
+    metadata:
+      labels:
+        app: postgres
     spec:
       containers:
       - name: postgres-job


### PR DESCRIPTION
## What does this PR do?

Adds the missing labels that is causing the gitops sync to fail:
```
Job.batch "configure-postgres-db" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: (retried 5 times).
```

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

### How to test changes / Special notes to the reviewer

Setup an OpenShift cluster and the required env vars, then run:

```
make install-no-rhoai
```
