### PR TITLE
feat: enable DCR authentication and RBAC defaultRole for MCP servers

### DIFF
--- a/charts/rhdh/templates/rbac-policy-configmap.yaml
+++ b/charts/rhdh/templates/rbac-policy-configmap.yaml
@@ -5,13 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   rbac-policy.csv: |
-    p, role:default/mcp-admin, catalog.entity.read, read, allow
-    p, role:default/mcp-admin, catalog.entity.create, create, allow
-    p, role:default/mcp-admin, intelligent-assistant.chat.read, read, allow
-    p, role:default/mcp-admin, intelligent-assistant.chat.create, create, allow
-    p, role:default/mcp-admin, intelligent-assistant.chat.update, update, allow
-    p, role:default/mcp-admin, intelligent-assistant.chat.delete, delete, allow
-    p, role:default/mcp-admin, intelligent-assistant.mcp.read, read, allow
     p, role:default/mcp-admin, intelligent-assistant.mcp.manage, update, allow
-    p, role:default/mcp-admin, intelligent-assistant.notebooks.use, update, allow
-    g, user:default/mfaisal, role:default/mcp-admin
+    g, user:default/jcollier, role:default/mcp-admin
+    g, user:default/mvaldron, role:default/mcp-admin
+    g, user:default/lucasyoon, role:default/mcp-admin

--- a/charts/rhdh/templates/rbac-policy-configmap.yaml
+++ b/charts/rhdh/templates/rbac-policy-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-rbac-policy
+  namespace: {{ .Release.Namespace }}
+data:
+  rbac-policy.csv: |
+    p, role:default/mcp-admin, catalog.entity.read, read, allow
+    p, role:default/mcp-admin, catalog.entity.create, create, allow
+    p, role:default/mcp-admin, intelligent-assistant.chat.read, read, allow
+    p, role:default/mcp-admin, intelligent-assistant.chat.create, create, allow
+    p, role:default/mcp-admin, intelligent-assistant.chat.update, update, allow
+    p, role:default/mcp-admin, intelligent-assistant.chat.delete, delete, allow
+    p, role:default/mcp-admin, intelligent-assistant.mcp.read, read, allow
+    p, role:default/mcp-admin, intelligent-assistant.mcp.manage, update, allow
+    p, role:default/mcp-admin, intelligent-assistant.notebooks.use, update, allow
+    g, user:default/mfaisal, role:default/mcp-admin

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -464,9 +464,26 @@ backstage:
           enabled: true
           rbac:
             policies-csv-file: /opt/app-root/src/rbac-policy.csv
+            defaultPermissions:
+              defaultRole: role:default/user
+              basicPermissions:
+                - permission: catalog.entity.read
+                  action: read
+                - permission: intelligent-assistant.chat.read
+                  action: read
+                - permission: intelligent-assistant.chat.create
+                  action: create
+                - permission: intelligent-assistant.chat.update
+                  action: update
+                - permission: intelligent-assistant.chat.delete
+                  action: delete
+                - permission: intelligent-assistant.mcp.read
+                  action: read
             admin:
               users:
-                - name: user:default/mfaisal
+                - name: user:default/jcollier
+                - name: user:default/mvaldron
+                - name: user:default/lucasyoon
         integrations:
           github:
             - apps:

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -306,6 +306,10 @@ backstage:
           # Enable experimental features for OIDC auth
           experimentalClientIdMetadataDocuments:
             enabled: true
+          experimentalDynamicClientRegistration:
+            enabled: true
+            allowedRedirectUriPatterns:
+              - '*'
           experimentalRefreshToken:
             enabled: true
           session:
@@ -453,9 +457,16 @@ backstage:
               provider_id: ${NOTEBOOKS_QUERY_PROVIDER_ID}
           mcpServers:
             - name: mcp-integration-tools
-              token: ${MCP_TOKEN}
+              auth: dcr
         mcpActions:
           namespacedToolNames: false
+        permission:
+          enabled: true
+          rbac:
+            policies-csv-file: /opt/app-root/src/rbac-policy.csv
+            admin:
+              users:
+                - name: user:default/mfaisal
         integrations:
           github:
             - apps:
@@ -721,6 +732,9 @@ backstage:
           mountPath: /tmp
         - name: extensions-catalog
           mountPath: /extensions
+        - name: rbac-policy
+          mountPath: /opt/app-root/src/rbac-policy.csv
+          subPath: rbac-policy.csv
       extraVolumes:
         - name: dynamic-plugins-root
           ephemeral:
@@ -746,6 +760,9 @@ backstage:
           emptyDir: {}
         - name: extensions-catalog
           emptyDir: {}
+        - name: rbac-policy
+          configMap:
+            name: "{{ .Release.Name }}-rbac-policy"
         # GCP SA JSON for Vertex AI. Pod volume is Helm-managed; lightspeed-core volumeMount is
         # applied by rolling-demo-sidecars-job until rhdh-chart gains lightspeed.core.extraVolumeMounts
         # (https://github.com/redhat-developer/rhdh-chart/pull/438) — that PostSync patch becomes redundant.

--- a/ci/values-ci.yaml
+++ b/ci/values-ci.yaml
@@ -33,6 +33,13 @@ backstage:
     enabled: false
   upstream:
     backstage:
+      appConfig:
+        permission:
+          enabled: false
+        intelligent-assistant:
+          mcpServers:
+            - name: mcp-integration-tools
+              token: ${MCP_TOKEN}
       # Helm replaces initContainers lists, so install-dynamic-plugins must be
       # restated when adding CI's byok-rag-init override.
       initContainers:


### PR DESCRIPTION
## Summary

- Enable Dynamic Client Registration (DCR) authentication for Intelligent Assistant MCP servers (`auth: dcr`)
- Configure RBAC with `defaultPermissions.defaultRole` so all SSO users get base IA + catalog permissions automatically
- Restrict MCP manage (toggle servers) to designated admins via CSV policy
- Remove hardcoded `backstage-plugin-auth` entries that conflicted with catalog index defaults

## Changes

**`charts/rhdh/values.yaml`**
- Set `auth: dcr` on MCP servers config
- Add `permission.rbac.defaultPermissions` with `defaultRole: role:default/user` and `basicPermissions` for catalog read + IA chat + MCP read
- Set `admin.users` to jcollier, mvaldron, lucasyoon (RBAC policy managers)

**`charts/rhdh/templates/rbac-policy-configmap.yaml`**
- Slim policy: only `intelligent-assistant.mcp.manage` for `role:default/mcp-admin`
- Assign 3 admins to mcp-admin role

## Test plan

- [x] All SSO users can access IA chat and view MCP servers (read-only)
- [x] MCP Settings shows "You have read-only access to MCP servers" for non-admins
- [x] DCR auth works end-to-end (chat query invokes MCP tools successfully)
- [ ] Admin users (jcollier/mvaldron/lucasyoon) can toggle MCP servers

Made with [Cursor](https://cursor.com)