### PR TITLE
fix(configure-postgres-db): sync options and automatic selector labels

### DIFF
--- a/charts/rhdh/templates/lightspeed-postgres.yaml
+++ b/charts/rhdh/templates/lightspeed-postgres.yaml
@@ -78,14 +78,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
-  manualSelector: true
-  selector:
-    matchLabels:
-      app: postgres
   template:
-    metadata:
-      labels:
-        app: postgres
     spec:
       containers:
       - name: postgres-job

--- a/charts/rhdh/templates/lightspeed-postgres.yaml
+++ b/charts/rhdh/templates/lightspeed-postgres.yaml
@@ -76,7 +76,7 @@ metadata:
   name: configure-postgres-db
   namespace: lightspeed-postgres
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   template:
     spec:


### PR DESCRIPTION
## What does this PR do?

Fixes the `configure-postgres-db` job specification by removing manual labeling added in #323 to restore automatic selector labeling and appending `Force=true` to `sync-options`.

Current sync state of ArgoCD is green:
<img width="1256" height="517" alt="Screenshot From 2026-08-24 18-12-19" src="https://github.com/user-attachments/assets/a885f9f9-2484-411b-8edc-34793273acfe" />


### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

### How to test changes / Special notes to the reviewer

Setup an OpenShift cluster and the required env vars, then run:

```
make install-no-rhoai
```
