### PR TITLE
fix(configure-postgres-db): sync options and automatic selector labels

### DIFF
--- a/charts/rhdh/templates/lightspeed-postgres.yaml
+++ b/charts/rhdh/templates/lightspeed-postgres.yaml
@@ -76,16 +76,9 @@ metadata:
   name: configure-postgres-db
   namespace: lightspeed-postgres
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  manualSelector: true
-  selector:
-    matchLabels:
-      app: postgres
   template:
-    metadata:
-      labels:
-        app: postgres
     spec:
       containers:
       - name: postgres-job


### PR DESCRIPTION
## What does this PR do?

Applies #329 gitops fix from `development` to address ongoing sync error.


Current sync state of ArgoCD is green (squashed with different sha, changes are the same):
<img width="1330" height="857" alt="Screenshot From 2026-08-24 16-53-26" src="https://github.com/user-attachments/assets/570b4b6d-9cfb-4490-910b-202e47c1e9c4" />


### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

### How to test changes / Special notes to the reviewer

Setup an OpenShift cluster and the required env vars, then run:

```
make install-no-rhoai
```