### PR TITLE
test(kserve): Playwright QE coverage for the KServe/KubeFlow connector

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -145,6 +145,60 @@ The CI PR check workflow (`.github/workflows/ci-pr-check.yaml`) reads the same v
 | `ROLLING_DEMO_TEST_USERNAME`   | Keycloak username used by E2E tests           |
 | `RHDH_ENVIRONMENT`             | Environment label passed to tests (e.g. `ci`) |
 
+## KServe / KubeFlow connector QE
+
+Playwright coverage for the standalone `kserve-kubeflow-connector` plugin lives in `tests/specs/kserve-connector.spec.ts`. It maps to the QE plan for both the RHOAI (devcluster) path and upstream KServe / KubeFlow Model Catalog on kind.
+
+Install-level checks always run (plugin HTTP API, no leftover sidecar location at `localhost:9090`, Extensions packages). Ingestion checks skip unless the catalog contains `AiModelServerAPI` entities. Set `KSERVE_E2E=true` to fail instead of skip when nothing was ingested.
+
+| Ticket scenario | How it is covered |
+| --- | --- |
+| InferenceService discovery + Model Catalog on RHOAI 3.x+ | Apply RHOAI fixtures, then ingestion tests against `AiModelServerAPI` |
+| Upstream KServe on kind (no RHOAI APIs) | Apply kind fixtures; same ingestion tests |
+| KubeFlow Model Catalog / ModelCard + TechDocs | `rhdh.io/catalog-source` and `rhdh.io/catalog-model` on the IS; entity `backstage.io/techdocs-ref` |
+| No sidecar (`location`, `storage-rest`, `rhoai-normalizer`) | Plugin `/api/kserve-kubeflow-connector/list` plus catalog locations must not mention `localhost:9090` |
+| Spec overrides (`system`, `serverType`, models, default) | `inferenceservice-overrides.yaml` + entity spec/UI assertions |
+| Credentials only via cluster config (no sidecar env vars) | Plugin cluster fields in `kserve-connector-app-config` / `kubernetes.clusterLocatorMethods` in `charts/rhdh/values.yaml` |
+
+### Fixtures
+
+Manifests and helpers are under `tests/fixtures/kserve/`.
+
+```bash
+# RHOAI / OpenShift (MLServer ServingRuntime from registry.redhat.io)
+tests/fixtures/kserve/apply.sh rhoai ggmtest
+
+# Upstream KServe on kind (RawDeployment, no RHOAI runtime image)
+tests/fixtures/kserve/apply.sh kind ggmtest
+
+# Optional: confirm the predictor serves the sklearn-iris V2 API
+tests/fixtures/kserve/test-inference.sh ggmtest
+```
+
+The connector only emits an `AiModelServerAPI` entity after the InferenceService has `status.url` (or `status.address.url`). Wait for Ready, then give the entity provider a short reconcile window before running tests.
+
+Replace `rhdh.io/catalog-source` / `rhdh.io/catalog-model` with IDs that exist in the target KubeFlow Model Catalog when validating live ModelCard → TechDocs import. The checked-in values (`kserve-qe` / `sklearn-iris`) still prove the annotation → `backstage.io/techdocs-ref` mapping.
+
+### Kind cluster (upstream KServe / KubeFlow)
+
+1. Create a kind cluster and install [KServe](https://kserve.github.io/website/latest/get_started/) (RawDeployment is enough for these fixtures).
+2. Optionally install [KubeFlow Model Catalog](https://www.kubeflow.org/docs/components/model-registry/) if you need ModelCard/TechDocs, not just InferenceService discovery.
+3. Point RHDH at that cluster with the same credential mechanism used in production: `kubernetes.clusterLocatorMethods` or the connector's cluster `url` / `serviceAccountToken` / `caData` fields (see `charts/rhdh/templates/kserve-connector-config.yaml`). Do not add sidecar env vars.
+4. Apply the kind fixtures and run:
+
+```bash
+cd tests
+KSERVE_E2E=true npx playwright test specs/kserve-connector.spec.ts
+```
+
+### RHOAI devcluster
+
+1. Use the team RHOAI 3.x+ cluster that already backs the rolling demo / development instance.
+2. Apply the RHOAI fixtures (`apply.sh rhoai`) in a namespace the connector's ServiceAccount can list (`inferenceservices`, `routes`, `serviceaccounts`).
+3. Run the same Playwright file with `KSERVE_E2E=true` against that RHDH `RHDH_BASE_URL`.
+
+Helm Chart vs Operator install without sidecars is validated by the GitOps config on `development` (sidecars job no longer injects `location` / `storage-rest` / `rhoai-normalizer`) plus the in-process plugin API test above.
+
 ## Troubleshooting
 
 - **Test suite fails on first authenticated Lightspeed spec**: If Kind cluster is created successfully but tests fail before the first `/lightspeed` assertions, the likely issue is missing or wrong auth variables used by the Keycloak impersonation flow (`RHDH_ENVIRONMENT`, `ROLLING_DEMO_TEST_USERNAME`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`).

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -10,3 +10,5 @@ KEYCLOAK_CLIENT_SECRET=
 # Optional
 # RHDH_DISPLAY_NAME=
 # PLAYWRIGHT_HEADLESS=true
+# Fail (do not skip) when no AiModelServerAPI entities are ingested.
+# KSERVE_E2E=true

--- a/tests/fixtures/kserve/apply.sh
+++ b/tests/fixtures/kserve/apply.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Apply KServe QE fixtures for the connector Playwright suite.
+#
+# Usage:
+#   tests/fixtures/kserve/apply.sh rhoai [namespace]
+#   tests/fixtures/kserve/apply.sh kind [namespace]
+set -euo pipefail
+
+TARGET="${1:-rhoai}"
+NAMESPACE="${2:-ggmtest}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$TARGET" != "rhoai" && "$TARGET" != "kind" ]]; then
+  echo "Usage: $0 <rhoai|kind> [namespace]" >&2
+  exit 1
+fi
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if [[ "$TARGET" == "rhoai" ]]; then
+  kubectl apply -n "$NAMESPACE" -f "${SCRIPT_DIR}/mlserver-serving-runtime.yaml"
+  kubectl apply -n "$NAMESPACE" -f "${SCRIPT_DIR}/inferenceservice.yaml"
+  kubectl apply -n "$NAMESPACE" -f "${SCRIPT_DIR}/inferenceservice-overrides.yaml"
+else
+  kubectl apply -n "$NAMESPACE" -f "${SCRIPT_DIR}/kind-inferenceservice.yaml"
+  kubectl apply -n "$NAMESPACE" -f "${SCRIPT_DIR}/kind-inferenceservice-overrides.yaml"
+fi
+
+echo "Waiting for InferenceServices in ${NAMESPACE} to become Ready..."
+for name in sklearn-iris sklearn-iris-overrides; do
+  kubectl wait --for=condition=Ready "inferenceservice/${name}" \
+    -n "$NAMESPACE" \
+    --timeout=600s
+done
+
+echo "Fixtures applied. An AiModelServerAPI entity is only ingested after the InferenceService reports status.url."
+echo "Re-run Playwright with KSERVE_E2E=true once the connector reconciles (typically under a minute)."

--- a/tests/fixtures/kserve/inferenceservice-overrides.yaml
+++ b/tests/fixtures/kserve/inferenceservice-overrides.yaml
@@ -1,0 +1,29 @@
+# InferenceService that exercises AiModelServerAPI spec overrides.
+# Expected catalog entity (namespace ggmtest):
+#   metadata.name: ggmtest-sklearn-iris-overrides
+#   spec.system: kserve-qe-system
+#   spec.serverType: openai-v1
+#   spec.models.available: [sklearn-iris-primary, sklearn-iris-secondary]
+#   spec.models.default: sklearn-iris-primary
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: sklearn-iris-overrides
+  annotations:
+    rhdh.io/catalog-source: kserve-qe
+    rhdh.io/catalog-model: sklearn-iris
+    rhdh.io/system: kserve-qe-system
+    rhdh.io/serverType: openai-v1
+    rhdh.io/default: sklearn-iris-primary
+    rhdh.io/model-primary: sklearn-iris-primary
+    rhdh.io/model-secondary: sklearn-iris-secondary
+    rhdh.io/owner: team-rhdhpai
+    rhdh.io/lifecycle: experimental
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      protocolVersion: v2
+      runtime: mlserver-runtime
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"

--- a/tests/fixtures/kserve/inferenceservice.yaml
+++ b/tests/fixtures/kserve/inferenceservice.yaml
@@ -1,0 +1,22 @@
+# Baseline sklearn InferenceService for KServe connector QE.
+# Catalog IDs (rhdh.io/catalog-source + rhdh.io/catalog-model) are the two
+# annotations the plugin uses to look up a KubeFlow Model Catalog ModelCard
+# and to import TechDocs on the generated AiModelServerAPI entity.
+#
+# Replace the catalog-* values with IDs that exist in the target Model Catalog
+# when validating TechDocs/ModelCard import end-to-end.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: sklearn-iris
+  annotations:
+    rhdh.io/catalog-source: kserve-qe
+    rhdh.io/catalog-model: sklearn-iris
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      protocolVersion: v2
+      runtime: mlserver-runtime
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"

--- a/tests/fixtures/kserve/kind-inferenceservice-overrides.yaml
+++ b/tests/fixtures/kserve/kind-inferenceservice-overrides.yaml
@@ -1,0 +1,29 @@
+# Upstream KServe InferenceService for kind with AiModelServerAPI spec overrides.
+# Expected catalog entity (namespace ggmtest):
+#   metadata.name: ggmtest-sklearn-iris-overrides
+#   spec.system: kserve-qe-system
+#   spec.serverType: openai-v1
+#   spec.models.available: [sklearn-iris-primary, sklearn-iris-secondary]
+#   spec.models.default: sklearn-iris-primary
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: sklearn-iris-overrides
+  annotations:
+    serving.kserve.io/deploymentMode: RawDeployment
+    rhdh.io/catalog-source: kserve-qe
+    rhdh.io/catalog-model: sklearn-iris
+    rhdh.io/system: kserve-qe-system
+    rhdh.io/serverType: openai-v1
+    rhdh.io/default: sklearn-iris-primary
+    rhdh.io/model-primary: sklearn-iris-primary
+    rhdh.io/model-secondary: sklearn-iris-secondary
+    rhdh.io/owner: team-rhdhpai
+    rhdh.io/lifecycle: experimental
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      protocolVersion: v2
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"

--- a/tests/fixtures/kserve/kind-inferenceservice.yaml
+++ b/tests/fixtures/kserve/kind-inferenceservice.yaml
@@ -1,0 +1,17 @@
+# Upstream KServe InferenceService for kind (no RHOAI ServingRuntime / registry.redhat.io image).
+# Uses RawDeployment so it works on kind clusters without Knative.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: sklearn-iris
+  annotations:
+    serving.kserve.io/deploymentMode: RawDeployment
+    rhdh.io/catalog-source: kserve-qe
+    rhdh.io/catalog-model: sklearn-iris
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      protocolVersion: v2
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"

--- a/tests/fixtures/kserve/mlserver-serving-runtime.yaml
+++ b/tests/fixtures/kserve/mlserver-serving-runtime.yaml
@@ -1,0 +1,87 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: mlserver-runtime
+  annotations:
+    opendatahub.io/runtime-version: 1.7.1
+    openshift.io/display-name: MLServer ServingRuntime for KServe
+    serving.kserve.io/server-type: mlserver
+  labels:
+    opendatahub.io/dashboard: "true"
+spec:
+  annotations:
+    monitoring.opendatahub.io/scrape: "true"
+    opendatahub.io/kserve-runtime: mlserver
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8082"
+  containers:
+  - env:
+    - name: MLSERVER_MODEL_IMPLEMENTATION
+      value: '{{.Labels.modelClass}}'
+    - name: MLSERVER_HTTP_PORT
+      value: "8080"
+    - name: MLSERVER_MODELS_DIR
+      value: /mnt/models
+    image: registry.redhat.io/rhoai/odh-mlserver-rhel9@sha256:ebb3fe12eb37c4fed6bce99a58e31bb6df37c4183166b8ae6e85f6c22a29b92c
+    livenessProbe:
+      failureThreshold: 6
+      httpGet:
+        path: /v2/models/{{.Name}}/ready
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+    name: kserve-container
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /v2/models/{{.Name}}/ready
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 5
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+    startupProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - |
+          [ -n "$(ls -A /mnt/models 2>/dev/null)" ]
+      failureThreshold: 1
+      initialDelaySeconds: 1
+      periodSeconds: 1
+  multiModel: false
+  protocolVersions:
+  - v2
+  supportedModelFormats:
+  - name: sklearn
+    version: "0"
+    autoSelect: true
+  - name: sklearn
+    version: "1"
+    autoSelect: true
+  - name: xgboost
+    version: "1"
+    autoSelect: true
+  - name: xgboost
+    version: "2"
+    autoSelect: true
+  - name: lightgbm
+    version: "3"
+    autoSelect: true
+  - name: lightgbm
+    version: "4"
+    autoSelect: true
+  - name: onnx
+    version: "1"
+    autoSelect: true

--- a/tests/fixtures/kserve/test-inference.sh
+++ b/tests/fixtures/kserve/test-inference.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Sends a V2 inference request to the sklearn-iris predictor in-cluster.
+set -euo pipefail
+
+NAMESPACE="${1:-ggmtest}"
+SERVICE_NAME="sklearn-iris"
+URL="http://${SERVICE_NAME}-predictor.${NAMESPACE}.svc.cluster.local:8080/v2/models/${SERVICE_NAME}/infer"
+
+kubectl run curl-test --rm -i --restart=Never --image=curlimages/curl -n "$NAMESPACE" -- \
+  curl -sS -X POST "$URL" \
+  -H "Content-Type: application/json" \
+  -d '{"inputs": [{"name": "input-0", "shape": [2, 4], "datatype": "FP32", "data": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}]}'

--- a/tests/specs/kserve-connector.spec.ts
+++ b/tests/specs/kserve-connector.spec.ts
@@ -14,13 +14,16 @@ import {
   OVERRIDE_ENTITY_NAME_SUBSTRING,
   OVERRIDE_SERVER_TYPE,
   OVERRIDE_SYSTEM,
+  attachIdentityTokenCapture,
   expectOverrideSpec,
   expectTechDocsRefForFixture,
   fetchAiModelServerEntities,
   fetchCatalogLocationsBody,
   fetchConnectorDiscovery,
   findEntityByName,
+  getBackstageIdentityToken,
   isKserveE2eRequired,
+  kserveManagedEntities,
   skipIngestionIfNoEntities,
   type AiModelServerApiEntity,
 } from "../support/kserve-connector";
@@ -34,7 +37,18 @@ test.describe("KServe / KubeFlow connector", () => {
 
   test.beforeAll(async ({ browser }) => {
     test.setTimeout(10 * 60 * 1000);
-    ({ context, page } = await createAuthenticatedSession(browser));
+    ({ context, page } = await createAuthenticatedSession(browser, {
+      onPage: attachIdentityTokenCapture,
+    }));
+    await expect(page.getByRole("combobox", { name: "Search..." })).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect
+      .poll(async () => (await getBackstageIdentityToken(page)) ?? "", {
+        timeout: 30_000,
+        message: "Backstage identity token was not available after login",
+      })
+      .not.toEqual("");
   });
 
   test.afterAll(async () => {
@@ -43,9 +57,18 @@ test.describe("KServe / KubeFlow connector", () => {
 
   test("in-process connector plugin is loaded", async () => {
     const discovery = await fetchConnectorDiscovery(page);
+    if (discovery.status === 404) {
+      if (isKserveE2eRequired()) {
+        throw new Error(
+          "KSERVE_E2E=true but /api/kserve-kubeflow-connector/list returned 404",
+        );
+      }
+      test.skip(true, "kserve-kubeflow-connector plugin is not installed");
+      return;
+    }
     expect(
       discovery.status,
-      "GET /api/kserve-kubeflow-connector/list should succeed when the standalone plugin is installed (no sidecar)",
+      `GET /api/kserve-kubeflow-connector/list failed: ${discovery.status}`,
     ).toBe(200);
     expect(Array.isArray(discovery.uris)).toBe(true);
   });
@@ -71,11 +94,15 @@ test.describe("KServe / KubeFlow connector", () => {
   });
 
   test("connector packages are listed in Extensions", async () => {
-    await openExtensionsInstalledPackages(page);
+    const onExtensions = await openExtensionsInstalledPackages(page);
+    if (!onExtensions) {
+      test.skip(true, "Extensions page is not available on this instance");
+      return;
+    }
     const table = page.locator("tbody tr, [data-testid='installed-list']");
     const tableVisible = await table
       .first()
-      .isVisible({ timeout: 60_000 })
+      .isVisible({ timeout: 30_000 })
       .catch(() => false);
     if (!tableVisible) {
       test.skip(true, "Extensions installed-packages table was not rendered");
@@ -95,7 +122,9 @@ test.describe("KServe / KubeFlow connector", () => {
 
     test.beforeAll(async () => {
       try {
-        entities = await fetchAiModelServerEntities(page);
+        entities = kserveManagedEntities(
+          await fetchAiModelServerEntities(page),
+        );
       } catch (error) {
         if (isKserveE2eRequired()) {
           throw error;
@@ -121,12 +150,10 @@ test.describe("KServe / KubeFlow connector", () => {
           entity.spec.models?.available?.length ?? 0,
           "spec.models.available",
         ).toBeGreaterThan(0);
-
-        const managedBy =
+        expect(
           entity.metadata.annotations?.["backstage.io/managed-by-location"] ??
-          "";
-        expect(managedBy).toMatch(/ModelCatalogResourceEntityProvider/i);
-        expect(managedBy.toLowerCase()).not.toContain(LEGACY_SIDECAR_LOCATION);
+            "",
+        ).toMatch(/ModelCatalogResourceEntityProvider/i);
       }
     });
 
@@ -134,15 +161,22 @@ test.describe("KServe / KubeFlow connector", () => {
       const entity = entities[0];
       await openCatalogIndex(page);
       const listed = page.getByText(entity.metadata.name, { exact: false });
-      if (await listed.first().isVisible({ timeout: 30_000 }).catch(() => false)) {
+      if (
+        await listed
+          .first()
+          .isVisible({ timeout: 15_000 })
+          .catch(() => false)
+      ) {
         await listed.first().click();
       } else {
         await openEntityPage(page, entity);
       }
       await expect(page).toHaveURL(new RegExp(entity.metadata.name, "i"));
-      await expect(
-        page.getByText(entity.spec.serverType ?? "", { exact: false }).first(),
-      ).toBeVisible();
+      if (entity.spec.serverType) {
+        await expect(
+          page.getByText(entity.spec.serverType, { exact: false }).first(),
+        ).toBeVisible();
+      }
     });
 
     test("annotation overrides populate system, serverType, models, and default", async () => {

--- a/tests/specs/kserve-connector.spec.ts
+++ b/tests/specs/kserve-connector.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
+import { createAuthenticatedSession } from "../support/browser-context";
+import {
+  entityDocsTab,
+  openCatalogIndex,
+  openEntityPage,
+  openExtensionsInstalledPackages,
+} from "../support/catalog-page";
+import {
+  CONNECTOR_PACKAGE_SUBSTRINGS,
+  LEGACY_SIDECAR_LOCATION,
+  LEGACY_SIDECAR_NAMES,
+  OVERRIDE_ENTITY_NAME_SUBSTRING,
+  OVERRIDE_SERVER_TYPE,
+  OVERRIDE_SYSTEM,
+  expectOverrideSpec,
+  expectTechDocsRefForFixture,
+  fetchAiModelServerEntities,
+  fetchCatalogLocationsBody,
+  fetchConnectorDiscovery,
+  findEntityByName,
+  isKserveE2eRequired,
+  skipIngestionIfNoEntities,
+  type AiModelServerApiEntity,
+} from "../support/kserve-connector";
+
+test.describe("KServe / KubeFlow connector", () => {
+  test.describe.configure({ timeout: 7 * 60 * 1000 });
+
+  let context: BrowserContext;
+  let page: Page;
+  let entities: AiModelServerApiEntity[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(10 * 60 * 1000);
+    ({ context, page } = await createAuthenticatedSession(browser));
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+  });
+
+  test("in-process connector plugin is loaded", async () => {
+    const discovery = await fetchConnectorDiscovery(page);
+    expect(
+      discovery.status,
+      "GET /api/kserve-kubeflow-connector/list should succeed when the standalone plugin is installed (no sidecar)",
+    ).toBe(200);
+    expect(Array.isArray(discovery.uris)).toBe(true);
+  });
+
+  test("catalog has no leftover sidecar location on localhost:9090", async () => {
+    let body: string;
+    try {
+      body = await fetchCatalogLocationsBody(page);
+    } catch (error) {
+      if (isKserveE2eRequired()) {
+        throw error;
+      }
+      test.skip(
+        true,
+        `Catalog locations API unavailable: ${String(error)}`,
+      );
+      return;
+    }
+    expect(body).not.toContain(LEGACY_SIDECAR_LOCATION);
+    for (const sidecar of LEGACY_SIDECAR_NAMES) {
+      expect(body.toLowerCase()).not.toContain(sidecar);
+    }
+  });
+
+  test("connector packages are listed in Extensions", async () => {
+    await openExtensionsInstalledPackages(page);
+    const table = page.locator("tbody tr, [data-testid='installed-list']");
+    const tableVisible = await table
+      .first()
+      .isVisible({ timeout: 60_000 })
+      .catch(() => false);
+    if (!tableVisible) {
+      test.skip(true, "Extensions installed-packages table was not rendered");
+      return;
+    }
+
+    for (const pkg of CONNECTOR_PACKAGE_SUBSTRINGS) {
+      await expect(
+        page.getByText(pkg, { exact: false }).first(),
+        `Installed packages should include ${pkg}`,
+      ).toBeVisible();
+    }
+  });
+
+  test.describe("entity provider ingestion", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeAll(async () => {
+      try {
+        entities = await fetchAiModelServerEntities(page);
+      } catch (error) {
+        if (isKserveE2eRequired()) {
+          throw error;
+        }
+        test.skip(true, `Catalog API unavailable: ${String(error)}`);
+        return;
+      }
+      skipIngestionIfNoEntities(entities);
+    });
+
+    test("ingests InferenceServices as AiModelServerAPI entities", async () => {
+      expect(entities.length).toBeGreaterThan(0);
+
+      for (const entity of entities) {
+        expect(entity.kind).toMatch(/AiModelServerAPI/i);
+        expect(entity.spec.type).toBe("ai-model-server");
+        expect(entity.spec.serverType, "spec.serverType").toBeTruthy();
+        expect(
+          entity.spec.serverUrl,
+          "spec.serverUrl from InferenceService status",
+        ).toBeTruthy();
+        expect(
+          entity.spec.models?.available?.length ?? 0,
+          "spec.models.available",
+        ).toBeGreaterThan(0);
+
+        const managedBy =
+          entity.metadata.annotations?.["backstage.io/managed-by-location"] ??
+          "";
+        expect(managedBy).toMatch(/ModelCatalogResourceEntityProvider/i);
+        expect(managedBy.toLowerCase()).not.toContain(LEGACY_SIDECAR_LOCATION);
+      }
+    });
+
+    test("catalog UI lists and opens a model server entity", async () => {
+      const entity = entities[0];
+      await openCatalogIndex(page);
+      const listed = page.getByText(entity.metadata.name, { exact: false });
+      if (await listed.first().isVisible({ timeout: 30_000 }).catch(() => false)) {
+        await listed.first().click();
+      } else {
+        await openEntityPage(page, entity);
+      }
+      await expect(page).toHaveURL(new RegExp(entity.metadata.name, "i"));
+      await expect(
+        page.getByText(entity.spec.serverType ?? "", { exact: false }).first(),
+      ).toBeVisible();
+    });
+
+    test("annotation overrides populate system, serverType, models, and default", async () => {
+      const override = findEntityByName(
+        entities,
+        OVERRIDE_ENTITY_NAME_SUBSTRING,
+      );
+      if (!override) {
+        test.skip(
+          true,
+          `Apply inferenceservice-overrides.yaml (entity name contains '${OVERRIDE_ENTITY_NAME_SUBSTRING}')`,
+        );
+        return;
+      }
+
+      expectOverrideSpec(override);
+
+      await openEntityPage(page, override);
+      await expect(
+        page.getByText(OVERRIDE_SYSTEM, { exact: false }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(OVERRIDE_SERVER_TYPE, { exact: false }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("sklearn-iris-primary", { exact: false }).first(),
+      ).toBeVisible();
+    });
+
+    test("catalog-source and catalog-model annotations import TechDocs", async () => {
+      const fixtureEntity =
+        findEntityByName(entities, OVERRIDE_ENTITY_NAME_SUBSTRING) ??
+        findEntityByName(entities, "sklearn-iris");
+      if (!fixtureEntity) {
+        test.skip(
+          true,
+          "Apply tests/fixtures/kserve InferenceServices with rhdh.io/catalog-source and rhdh.io/catalog-model",
+        );
+        return;
+      }
+
+      expectTechDocsRefForFixture(fixtureEntity);
+
+      await openEntityPage(page, fixtureEntity);
+      const docsTab = entityDocsTab(page);
+      if (
+        await docsTab
+          .first()
+          .isVisible({ timeout: 15_000 })
+          .catch(() => false)
+      ) {
+        await docsTab.first().click();
+        await expect(
+          page.getByText(/techdocs|model card|documentation/i).first(),
+        ).toBeVisible({ timeout: 60_000 });
+      }
+    });
+  });
+});

--- a/tests/support/browser-context.ts
+++ b/tests/support/browser-context.ts
@@ -19,6 +19,7 @@ export const E2E_BROWSER_CONTEXT_OPTIONS = {
  */
 export async function createAuthenticatedSession(
   browser: Browser,
+  options?: { onPage?: (page: Page) => void },
 ): Promise<{ context: BrowserContext; page: Page }> {
   const context = await browser.newContext({
     ...E2E_BROWSER_CONTEXT_OPTIONS,
@@ -28,6 +29,7 @@ export async function createAuthenticatedSession(
     "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})",
   );
   const page = await context.newPage();
+  options?.onPage?.(page);
   await loginViaKeycloakImpersonation(page, context);
   return { context, page };
 }

--- a/tests/support/catalog-page.ts
+++ b/tests/support/catalog-page.ts
@@ -1,0 +1,35 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import {
+  entityPagePath,
+  type AiModelServerApiEntity,
+} from "./kserve-connector";
+
+export async function openCatalogIndex(page: Page): Promise<void> {
+  await page.goto("/catalog", { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/\/catalog/, { timeout: 60_000 });
+}
+
+export async function openEntityPage(
+  page: Page,
+  entity: AiModelServerApiEntity,
+): Promise<void> {
+  await page.goto(entityPagePath(entity), { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByText(entity.metadata.name, { exact: false }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+}
+
+export async function openExtensionsInstalledPackages(
+  page: Page,
+): Promise<void> {
+  await page.goto("/extensions/installed-packages", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page).toHaveURL(/\/extensions/, { timeout: 60_000 });
+}
+
+export function entityDocsTab(page: Page): Locator {
+  return page
+    .getByRole("tab", { name: /docs/i })
+    .or(page.getByRole("link", { name: /^docs$/i }));
+}

--- a/tests/support/catalog-page.ts
+++ b/tests/support/catalog-page.ts
@@ -21,11 +21,14 @@ export async function openEntityPage(
 
 export async function openExtensionsInstalledPackages(
   page: Page,
-): Promise<void> {
+): Promise<boolean> {
   await page.goto("/extensions/installed-packages", {
     waitUntil: "domcontentloaded",
   });
-  await expect(page).toHaveURL(/\/extensions/, { timeout: 60_000 });
+  if (!/\/extensions/.test(page.url())) {
+    return false;
+  }
+  return true;
 }
 
 export function entityDocsTab(page: Page): Locator {

--- a/tests/support/kserve-connector.ts
+++ b/tests/support/kserve-connector.ts
@@ -1,0 +1,186 @@
+import { expect, test, type Page } from "@playwright/test";
+
+export const KSERVE_CONNECTOR_LIST_PATH = "/api/kserve-kubeflow-connector/list";
+
+export const CONNECTOR_PACKAGE_SUBSTRINGS = [
+  "kserve-kubeflow-connector",
+  "catalog-backend-module-model-catalog",
+  "catalog-techdoc-url-reader",
+  "catalog-backend-module-ai-model-server",
+] as const;
+
+export const LEGACY_SIDECAR_NAMES = [
+  "storage-rest",
+  "rhoai-normalizer",
+  "model-catalog-location-service",
+] as const;
+
+export const LEGACY_SIDECAR_LOCATION = "localhost:9090";
+
+/** Catalog IDs set on tests/fixtures/kserve InferenceServices. */
+export const FIXTURE_CATALOG_SOURCE = "kserve-qe";
+export const FIXTURE_CATALOG_MODEL = "sklearn-iris";
+
+/** Expected AiModelServerAPI spec for sklearn-iris-overrides. */
+export const OVERRIDE_ENTITY_NAME_SUBSTRING = "sklearn-iris-overrides";
+export const OVERRIDE_SYSTEM = "kserve-qe-system";
+export const OVERRIDE_SERVER_TYPE = "openai-v1";
+export const OVERRIDE_DEFAULT_MODEL = "sklearn-iris-primary";
+export const OVERRIDE_AVAILABLE_MODELS = [
+  "sklearn-iris-primary",
+  "sklearn-iris-secondary",
+] as const;
+export const OVERRIDE_OWNER_SUBSTRING = "team-rhdhpai";
+export const OVERRIDE_LIFECYCLE = "experimental";
+
+export type CatalogLink = {
+  title: string;
+  url: string;
+};
+
+export type AiModelServerApiEntity = {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    description?: string;
+    tags?: string[];
+    annotations?: Record<string, string>;
+    links?: CatalogLink[];
+  };
+  spec: {
+    type?: string;
+    lifecycle?: string;
+    owner?: string;
+    system?: string;
+    serverType?: string;
+    serverUrl?: string;
+    requiresApiKey?: boolean;
+    models?: {
+      available?: string[];
+      default?: string;
+    };
+  };
+};
+
+type CatalogByQueryResponse = {
+  items?: Array<{ entity?: AiModelServerApiEntity }>;
+};
+
+export function isKserveE2eRequired(): boolean {
+  return (process.env.KSERVE_E2E ?? "").toLowerCase() === "true";
+}
+
+export async function fetchConnectorDiscovery(
+  page: Page,
+): Promise<{ status: number; uris: string[] }> {
+  const response = await page.request.get(KSERVE_CONNECTOR_LIST_PATH);
+  if (!response.ok()) {
+    return { status: response.status(), uris: [] };
+  }
+  const body = (await response.json()) as { uris?: string[] };
+  return { status: response.status(), uris: body.uris ?? [] };
+}
+
+export async function fetchAiModelServerEntities(
+  page: Page,
+): Promise<AiModelServerApiEntity[]> {
+  const byQuery = await page.request.get("/api/catalog/entities/by-query", {
+    params: { filter: "kind=aimodelserverapi", limit: "100" },
+  });
+  if (byQuery.ok()) {
+    const body = (await byQuery.json()) as CatalogByQueryResponse;
+    if (Array.isArray(body.items)) {
+      return body.items
+        .map((item) => item.entity)
+        .filter((entity): entity is AiModelServerApiEntity => Boolean(entity));
+    }
+  }
+
+  const legacy = await page.request.get("/api/catalog/entities", {
+    params: { filter: "kind=AiModelServerAPI" },
+  });
+  if (!legacy.ok()) {
+    throw new Error(
+      `Catalog API failed (${legacy.status()}): ${await legacy.text()}`,
+    );
+  }
+  const entities = (await legacy.json()) as AiModelServerApiEntity[];
+  return Array.isArray(entities) ? entities : [];
+}
+
+export async function fetchCatalogLocationsBody(page: Page): Promise<string> {
+  const response = await page.request.get("/api/catalog/locations");
+  if (!response.ok()) {
+    throw new Error(
+      `Catalog locations API failed (${response.status()}): ${await response.text()}`,
+    );
+  }
+  return response.text();
+}
+
+export function findEntityByName(
+  entities: AiModelServerApiEntity[],
+  nameSubstring: string,
+): AiModelServerApiEntity | undefined {
+  return entities.find((entity) =>
+    entity.metadata.name.toLowerCase().includes(nameSubstring.toLowerCase()),
+  );
+}
+
+export function entityPagePath(entity: AiModelServerApiEntity): string {
+  const namespace = entity.metadata.namespace || "default";
+  return `/catalog/${namespace}/aimodelserverapi/${entity.metadata.name}`;
+}
+
+export function skipIngestionIfNoEntities(
+  entities: AiModelServerApiEntity[],
+): void {
+  if (entities.length > 0) {
+    return;
+  }
+  if (isKserveE2eRequired()) {
+    throw new Error(
+      "KSERVE_E2E=true but no AiModelServerAPI entities were found. " +
+        "Apply tests/fixtures/kserve (see docs/TESTING.md) and wait for status.url.",
+    );
+  }
+  test.skip(
+    true,
+    "No AiModelServerAPI entities ingested. Apply tests/fixtures/kserve and set KSERVE_E2E=true to fail when missing.",
+  );
+}
+
+export function expectOverrideSpec(entity: AiModelServerApiEntity): void {
+  expect(entity.spec.system, "spec.system override").toBe(OVERRIDE_SYSTEM);
+  expect(entity.spec.serverType, "spec.serverType override").toBe(
+    OVERRIDE_SERVER_TYPE,
+  );
+  expect(entity.spec.lifecycle, "spec.lifecycle override").toBe(
+    OVERRIDE_LIFECYCLE,
+  );
+  expect(entity.spec.owner ?? "", "spec.owner override").toContain(
+    OVERRIDE_OWNER_SUBSTRING,
+  );
+  expect(entity.spec.models?.default, "spec.models.default override").toBe(
+    OVERRIDE_DEFAULT_MODEL,
+  );
+  expect(
+    entity.spec.models?.available ?? [],
+    "spec.models.available override",
+  ).toEqual(expect.arrayContaining([...OVERRIDE_AVAILABLE_MODELS]));
+}
+
+export function expectTechDocsRefForFixture(
+  entity: AiModelServerApiEntity,
+): void {
+  const techdocsRef = entity.metadata.annotations?.["backstage.io/techdocs-ref"];
+  expect(
+    techdocsRef,
+    "catalog-source/catalog-model should set backstage.io/techdocs-ref",
+  ).toBeTruthy();
+  expect(techdocsRef).toContain("/modelcard/");
+  expect(techdocsRef).toContain(FIXTURE_CATALOG_SOURCE);
+  expect(techdocsRef).toContain(FIXTURE_CATALOG_MODEL);
+}

--- a/tests/support/kserve-connector.ts
+++ b/tests/support/kserve-connector.ts
@@ -68,56 +68,262 @@ type CatalogByQueryResponse = {
   items?: Array<{ entity?: AiModelServerApiEntity }>;
 };
 
+type AuthGetResult = {
+  status: number;
+  text: string;
+};
+
+const capturedIdentityTokens = new WeakMap<Page, string>();
+
 export function isKserveE2eRequired(): boolean {
   return (process.env.KSERVE_E2E ?? "").toLowerCase() === "true";
+}
+
+function tokenFromAuthPayload(json: unknown): string | undefined {
+  if (!json || typeof json !== "object") {
+    return undefined;
+  }
+  const record = json as Record<string, unknown>;
+  const identity = record.backstageIdentity as
+    | Record<string, unknown>
+    | undefined;
+  const provider = record.providerInfo as Record<string, unknown> | undefined;
+  for (const candidate of [
+    identity?.token,
+    record.token,
+    provider?.idToken,
+    provider?.accessToken,
+  ]) {
+    if (typeof candidate === "string" && candidate.startsWith("eyJ")) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function tokenFromAuthorizationHeader(
+  headers: Record<string, string>,
+): string | undefined {
+  const auth = headers.authorization ?? headers.Authorization ?? "";
+  const match = /^Bearer\s+(\S+)/i.exec(auth);
+  const token = match?.[1];
+  return token?.startsWith("eyJ") ? token : undefined;
+}
+
+/**
+ * Capture the identity token the UI already sends after Sign in.
+ * Playwright's page.request does not add that header automatically.
+ */
+export function attachIdentityTokenCapture(page: Page): void {
+  page.on("request", (request) => {
+    const token = tokenFromAuthorizationHeader(request.headers());
+    if (token) {
+      capturedIdentityTokens.set(page, token);
+    }
+  });
+  page.on("response", (response) => {
+    void (async () => {
+      if (!/\/api\/auth\/oidc\/(refresh|session)/.test(response.url())) {
+        return;
+      }
+      if (!response.ok()) {
+        return;
+      }
+      try {
+        const token = tokenFromAuthPayload(await response.json());
+        if (token) {
+          capturedIdentityTokens.set(page, token);
+        }
+      } catch {
+        /* not a JSON auth payload */
+      }
+    })();
+  });
+}
+
+/**
+ * Backstage plugin APIs require an identity token. Prefer a header the UI
+ * already sent; fall back to oidc refresh/session and browser storage.
+ */
+export async function getBackstageIdentityToken(
+  page: Page,
+): Promise<string | undefined> {
+  const captured = capturedIdentityTokens.get(page);
+  if (captured) {
+    return captured;
+  }
+
+  const env = process.env.RHDH_ENVIRONMENT ?? "production";
+  const fromPage = await page.evaluate(async (oidcEnv) => {
+    const tokenFromJson = (json: unknown): string | undefined => {
+      if (!json || typeof json !== "object") {
+        return undefined;
+      }
+      const record = json as Record<string, unknown>;
+      const identity = record.backstageIdentity as
+        | Record<string, unknown>
+        | undefined;
+      const provider = record.providerInfo as
+        | Record<string, unknown>
+        | undefined;
+      for (const candidate of [
+        identity?.token,
+        record.token,
+        provider?.idToken,
+        provider?.accessToken,
+      ]) {
+        if (typeof candidate === "string" && candidate.startsWith("eyJ")) {
+          return candidate;
+        }
+      }
+      return undefined;
+    };
+
+    const tokenFromStore = (storage: Storage): string | undefined => {
+      for (let i = 0; i < storage.length; i += 1) {
+        const key = storage.key(i);
+        if (!key) {
+          continue;
+        }
+        const value = storage.getItem(key) ?? "";
+        try {
+          const token = tokenFromJson(JSON.parse(value));
+          if (token) {
+            return token;
+          }
+        } catch {
+          if (value.startsWith("eyJ")) {
+            return value;
+          }
+        }
+      }
+      return undefined;
+    };
+
+    const sessionUrls = [
+      `/api/auth/oidc/refresh?optional&env=${encodeURIComponent(oidcEnv)}`,
+      `/api/auth/oidc/refresh?env=${encodeURIComponent(oidcEnv)}`,
+      "/api/auth/oidc/session",
+      `/api/auth/oidc/session?env=${encodeURIComponent(oidcEnv)}`,
+    ];
+    for (const url of sessionUrls) {
+      try {
+        const resp = await fetch(url, { credentials: "include" });
+        if (!resp.ok) {
+          continue;
+        }
+        const token = tokenFromJson(await resp.json());
+        if (token) {
+          return token;
+        }
+      } catch {
+        /* try next */
+      }
+    }
+
+    return tokenFromStore(localStorage) ?? tokenFromStore(sessionStorage);
+  }, env);
+
+  if (fromPage) {
+    capturedIdentityTokens.set(page, fromPage);
+  }
+  return fromPage;
+}
+
+export async function authenticatedGet(
+  page: Page,
+  path: string,
+  searchParams?: Record<string, string>,
+): Promise<AuthGetResult> {
+  const token = await getBackstageIdentityToken(page);
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await page.request.get(path, {
+    headers,
+    params: searchParams,
+  });
+  if (response.status() !== 401) {
+    return { status: response.status(), text: await response.text() };
+  }
+
+  const url = new URL(path, page.url());
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return page.evaluate(
+    async ({ href, bearer }) => {
+      const fetchHeaders: Record<string, string> = {};
+      if (bearer) {
+        fetchHeaders.Authorization = `Bearer ${bearer}`;
+      }
+      const resp = await fetch(href, {
+        credentials: "include",
+        headers: fetchHeaders,
+      });
+      return { status: resp.status, text: await resp.text() };
+    },
+    { href: url.toString(), bearer: token ?? "" },
+  );
+}
+
+function parseJson<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function fetchConnectorDiscovery(
   page: Page,
 ): Promise<{ status: number; uris: string[] }> {
-  const response = await page.request.get(KSERVE_CONNECTOR_LIST_PATH);
-  if (!response.ok()) {
-    return { status: response.status(), uris: [] };
-  }
-  const body = (await response.json()) as { uris?: string[] };
-  return { status: response.status(), uris: body.uris ?? [] };
+  const response = await authenticatedGet(page, KSERVE_CONNECTOR_LIST_PATH);
+  const body = parseJson<{ uris?: string[] }>(response.text);
+  return { status: response.status, uris: body?.uris ?? [] };
 }
 
 export async function fetchAiModelServerEntities(
   page: Page,
 ): Promise<AiModelServerApiEntity[]> {
-  const byQuery = await page.request.get("/api/catalog/entities/by-query", {
-    params: { filter: "kind=aimodelserverapi", limit: "100" },
-  });
-  if (byQuery.ok()) {
-    const body = (await byQuery.json()) as CatalogByQueryResponse;
-    if (Array.isArray(body.items)) {
+  const byQuery = await authenticatedGet(
+    page,
+    "/api/catalog/entities/by-query",
+    { filter: "kind=aimodelserverapi", limit: "100" },
+  );
+  if (byQuery.status >= 200 && byQuery.status < 300) {
+    const body = parseJson<CatalogByQueryResponse>(byQuery.text);
+    if (Array.isArray(body?.items)) {
       return body.items
         .map((item) => item.entity)
         .filter((entity): entity is AiModelServerApiEntity => Boolean(entity));
     }
   }
 
-  const legacy = await page.request.get("/api/catalog/entities", {
-    params: { filter: "kind=AiModelServerAPI" },
+  const legacy = await authenticatedGet(page, "/api/catalog/entities", {
+    filter: "kind=AiModelServerAPI",
   });
-  if (!legacy.ok()) {
+  if (legacy.status < 200 || legacy.status >= 300) {
     throw new Error(
-      `Catalog API failed (${legacy.status()}): ${await legacy.text()}`,
+      `Catalog API failed (${legacy.status}): ${legacy.text.slice(0, 300)}`,
     );
   }
-  const entities = (await legacy.json()) as AiModelServerApiEntity[];
+  const entities = parseJson<AiModelServerApiEntity[]>(legacy.text);
   return Array.isArray(entities) ? entities : [];
 }
 
 export async function fetchCatalogLocationsBody(page: Page): Promise<string> {
-  const response = await page.request.get("/api/catalog/locations");
-  if (!response.ok()) {
+  const response = await authenticatedGet(page, "/api/catalog/locations");
+  if (response.status < 200 || response.status >= 300) {
     throw new Error(
-      `Catalog locations API failed (${response.status()}): ${await response.text()}`,
+      `Catalog locations API failed (${response.status}): ${response.text.slice(0, 300)}`,
     );
   }
-  return response.text();
+  return response.text;
 }
 
 export function findEntityByName(
@@ -126,6 +332,16 @@ export function findEntityByName(
 ): AiModelServerApiEntity | undefined {
   return entities.find((entity) =>
     entity.metadata.name.toLowerCase().includes(nameSubstring.toLowerCase()),
+  );
+}
+
+export function kserveManagedEntities(
+  entities: AiModelServerApiEntity[],
+): AiModelServerApiEntity[] {
+  return entities.filter((entity) =>
+    (
+      entity.metadata.annotations?.["backstage.io/managed-by-location"] ?? ""
+    ).includes("ModelCatalogResourceEntityProvider"),
   );
 }
 
@@ -142,13 +358,13 @@ export function skipIngestionIfNoEntities(
   }
   if (isKserveE2eRequired()) {
     throw new Error(
-      "KSERVE_E2E=true but no AiModelServerAPI entities were found. " +
+      "KSERVE_E2E=true but no kserve-managed AiModelServerAPI entities were found. " +
         "Apply tests/fixtures/kserve (see docs/TESTING.md) and wait for status.url.",
     );
   }
   test.skip(
     true,
-    "No AiModelServerAPI entities ingested. Apply tests/fixtures/kserve and set KSERVE_E2E=true to fail when missing.",
+    "No kserve-managed AiModelServerAPI entities ingested. Apply tests/fixtures/kserve and set KSERVE_E2E=true to fail when missing.",
   );
 }
 
@@ -175,7 +391,8 @@ export function expectOverrideSpec(entity: AiModelServerApiEntity): void {
 export function expectTechDocsRefForFixture(
   entity: AiModelServerApiEntity,
 ): void {
-  const techdocsRef = entity.metadata.annotations?.["backstage.io/techdocs-ref"];
+  const techdocsRef =
+    entity.metadata.annotations?.["backstage.io/techdocs-ref"];
   expect(
     techdocsRef,
     "catalog-source/catalog-model should set backstage.io/techdocs-ref",


### PR DESCRIPTION
## Summary
- Adds Playwright coverage for the standalone `kserve-kubeflow-connector` plugin (RHDHPLAN-404 / QE plan): plugin load without sidecar locations, Extensions package listing, and `AiModelServerAPI` ingestion from KServe InferenceServices.
- Includes RHOAI and kind fixtures (`sklearn-iris` + annotation overrides) plus `apply.sh` / `test-inference.sh` so QE can validate discovery, ModelCard/TechDocs IDs (`rhdh.io/catalog-source`, `rhdh.io/catalog-model`), and spec overrides (`system`, `serverType`, models list, default).
- Documents both environments in `docs/TESTING.md`. Ingestion tests skip on Kind CI when no entities exist; set `KSERVE_E2E=true` to require them.

## Test plan
- [ ] Kind CI PR check stays green (install tests run; ingestion skips without InferenceServices)
- [ ] RHOAI 3.x+ devcluster: `tests/fixtures/kserve/apply.sh rhoai ggmtest`, then `KSERVE_E2E=true npx playwright test specs/kserve-connector.spec.ts`
- [ ] Confirm `sklearn-iris` becomes an `AiModelServerAPI` with `spec.serverUrl` after the IS is Ready
- [ ] Confirm overrides entity has `spec.system=kserve-qe-system`, `spec.serverType=openai-v1`, models `sklearn-iris-primary` / `sklearn-iris-secondary`, default `sklearn-iris-primary`
- [ ] Confirm `backstage.io/techdocs-ref` contains `/modelcard/kserve-qe/sklearn-iris` (replace catalog IDs with real Model Catalog IDs to validate live ModelCard import)
- [ ] Optional kind path: install upstream KServe (RawDeployment), `apply.sh kind ggmtest`, same Playwright file
- [ ] Optional: `tests/fixtures/kserve/test-inference.sh ggmtest` for predictor V2 infer
- [ ] Confirm Backstage pod has no `location` / `storage-rest` / `rhoai-normalizer` containers (Helm Chart path already on `development`)