### PR TITLE
fix(kserve): Helm-manage kserve-connector-secrets so staging can start

### DIFF
--- a/charts/rhdh/templates/kserve-connector-secrets.yaml
+++ b/charts/rhdh/templates/kserve-connector-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kserve-connector-secrets
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  K8S_CLUSTER_URL: "https://kubernetes.default.svc"
+  K8S_SA_TOKEN: ""
+  K8S_CA_DATA: ""
+  KUBEFLOW_MODEL_CATALOG_URL: ""

--- a/charts/rhdh/values.yaml
+++ b/charts/rhdh/values.yaml
@@ -701,6 +701,23 @@ backstage:
           value: "app-next"
         - name: ENABLE_STANDARD_MODULE_FEDERATION
           value: "true"
+        # Prefer the Helm-managed SA token. extraEnvVars override envFrom, so an
+        # empty kserve-connector-secrets (or a missing one after this template
+        # ships) cannot keep Backstage from starting.
+        - name: K8S_CLUSTER_URL
+          value: "https://kubernetes.default.svc"
+        - name: K8S_SA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: rhdh-rhoai-bridge-token
+              key: token
+              optional: true
+        - name: K8S_CA_DATA
+          valueFrom:
+            secretKeyRef:
+              name: rhdh-rhoai-bridge-token
+              key: ca.crt
+              optional: true
       extraEnvVarsSecrets:
         - github-secrets
         - kubernetes-secrets


### PR DESCRIPTION
## Summary
- PR #301 added `kserve-connector-secrets` to `extraEnvVarsSecrets` but did not create the Secret in Helm. ArgoCD sync on `development` therefore cannot start Backstage (`CreateContainerConfigError` → route 503).
- Add a chart Secret with the required keys and inject `K8S_SA_TOKEN` / `K8S_CA_DATA` from the Helm-managed `rhdh-rhoai-bridge-token` (optional so Kind CI stays green).

## Test plan
- [ ] ArgoCD sync on `rhdhai-development` creates `kserve-connector-secrets`
- [ ] Backstage route returns 200
- [ ] Kind CI still passes
